### PR TITLE
Provide language parameter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,18 @@
 Changelog
 =========
 
+1.4.0
+-----
+
+Supported geoLink schema versions: v1.0.0, v1.1.0, v1.1.1 (default)
+
+- Add test for arbitrary URL parameters
+
+
 1.3.2
 -----
+
+Supported geoLink schema versions: v1.0.0, v1.1.0, v1.1.1 (default)
 
 - Move repository to GitHub openoereb
 - Use defusedxml for XML parsing

--- a/geolink_formatter/__init__.py
+++ b/geolink_formatter/__init__.py
@@ -6,7 +6,7 @@ from geolink_formatter.format import HTML
 from geolink_formatter.parser import XML
 
 
-__version__ = '1.3.2'
+__version__ = '1.4.0'
 
 
 class GeoLinkFormatter(object):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requires = [
 ]
 
 setup(name='geolink_formatter',
-      version='1.3.2',
+      version='1.4.0',
       description='OEREBlex geoLink Formatter',
       license='BSD',
       long_description='{readme}\n\n{changelog}'.format(readme=readme, changelog=changelog),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -184,6 +184,17 @@ def test_schema_version_1_1_1():
     assert documents[0].abrogation_date.strftime(fmt) == '2008-12-31'
 
 
+def test_default_version_with_locale():
+    fmt = '%Y-%m-%d'
+    with requests_mock.mock() as m:
+        with open('tests/resources/geolink_v1.1.1.xml', 'rb') as f:
+            m.get('http://oereblex.test.com/api/geolinks/1500.xml?locale=fr', content=f.read())
+        documents = XML().from_url('http://oereblex.test.com/api/geolinks/1500.xml', {'locale': 'fr'})
+    assert documents[0].number == '1A'
+    assert documents[0].abbreviation == 'abbr'
+    assert documents[0].abrogation_date.strftime(fmt) == '2008-12-31'
+
+
 def test_dtd_validation_valid():
     content = XML(dtd_validation=True, xsd_validation=False)._parse_xml(
         """<?xml version="1.1" encoding="utf-8"?>


### PR DESCRIPTION
There is no additional parameter needed to pass the language. The method `from_url()` has an argument `params` which accepts a dictionary with arbitratry URL parameters.

Closes #58