### PR TITLE
Add attribute "approval_date"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ Supported geoLink schema versions: v1.0.0, v1.1.0, v1.1.1 (default)
 - Add test for arbitrary URL parameters
 - Add enumeration value "Bezirk" for attribute "federal_level"
 - If available, show abrogation date instead of files in HTML output
-- Add "approval_date" in schema to fix issue at Canton AI
+- Add additional attributes in schema (approval_date, publication_date and cycle)
 
 
 1.3.2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ Supported geoLink schema versions: v1.0.0, v1.1.0, v1.1.1 (default)
 - Add test for arbitrary URL parameters
 - Add enumeration value "Bezirk" for attribute "federal_level"
 - If available, show abrogation date instead of files in HTML output
+- Add "approval_date" in schema to fix issue at Canton AI
 
 
 1.3.2

--- a/geolink_formatter/schema/v1.0.0.xsd
+++ b/geolink_formatter/schema/v1.0.0.xsd
@@ -58,6 +58,7 @@
                         <xs:attribute name="decree_date" type="xs:string"/>
                         <xs:attribute name="enactment_date" type="xs:string"/>
                         <xs:attribute name="approval_date" type="xs:string"/>
+                        <xs:attribute name="publication_date" type="xs:string"/>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>

--- a/geolink_formatter/schema/v1.0.0.xsd
+++ b/geolink_formatter/schema/v1.0.0.xsd
@@ -57,6 +57,7 @@
                         <xs:attribute name="subtype" type="xs:string"/>
                         <xs:attribute name="decree_date" type="xs:string"/>
                         <xs:attribute name="enactment_date" type="xs:string"/>
+                        <xs:attribute name="approval_date" type="xs:string"/>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>

--- a/geolink_formatter/schema/v1.1.0.xsd
+++ b/geolink_formatter/schema/v1.1.0.xsd
@@ -50,6 +50,7 @@
                         </xs:attribute>
                         <xs:attribute name="authority" type="xs:string"/>
                         <xs:attribute name="authority_url" type="xs:string"/>
+                        <xs:attribute name="cycle" type="xs:string"/>
                         <xs:attribute name="title" type="xs:string"/>
                         <xs:attribute name="number" type="xs:string"/>
                         <xs:attribute name="abbreviation" type="xs:string"/>
@@ -60,6 +61,7 @@
                         <xs:attribute name="enactment_date" type="xs:string"/>
                         <xs:attribute name="abrogation_date" type="xs:string"/>
                         <xs:attribute name="approval_date" type="xs:string"/>
+                        <xs:attribute name="publication_date" type="xs:string"/>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>

--- a/geolink_formatter/schema/v1.1.0.xsd
+++ b/geolink_formatter/schema/v1.1.0.xsd
@@ -59,6 +59,7 @@
                         <xs:attribute name="decree_date" type="xs:string"/>
                         <xs:attribute name="enactment_date" type="xs:string"/>
                         <xs:attribute name="abrogation_date" type="xs:string"/>
+                        <xs:attribute name="approval_date" type="xs:string"/>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>

--- a/geolink_formatter/schema/v1.1.1.xsd
+++ b/geolink_formatter/schema/v1.1.1.xsd
@@ -50,6 +50,7 @@
                         </xs:attribute>
                         <xs:attribute name="authority" type="xs:string"/>
                         <xs:attribute name="authority_url" type="xs:string"/>
+                        <xs:attribute name="cycle" type="xs:string"/>
                         <xs:attribute name="title" type="xs:string"/>
                         <xs:attribute name="number" type="xs:string"/>
                         <xs:attribute name="abbreviation" type="xs:string"/>
@@ -60,6 +61,7 @@
                         <xs:attribute name="enactment_date" type="xs:string"/>
                         <xs:attribute name="abrogation_date" type="xs:string"/>
                         <xs:attribute name="approval_date" type="xs:string"/>
+                        <xs:attribute name="publication_date" type="xs:string"/>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>

--- a/geolink_formatter/schema/v1.1.1.xsd
+++ b/geolink_formatter/schema/v1.1.1.xsd
@@ -59,6 +59,7 @@
                         <xs:attribute name="decree_date" type="xs:string"/>
                         <xs:attribute name="enactment_date" type="xs:string"/>
                         <xs:attribute name="abrogation_date" type="xs:string"/>
+                        <xs:attribute name="approval_date" type="xs:string"/>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>


### PR DESCRIPTION
Add new property `approval_date` to `Document` elements. This addition is needed to fix an issue with the data at Canton AI.

Closes #56