### PR TITLE
Prepare for new OEREBlex API version 1.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Supported geoLink schema versions: v1.0.0, v1.1.0, v1.1.1, v1.2.0 (default)
+
+- Add support for geoLink schema version 1.2.0
+- New document attribute 'language'
+- New doctype 'notice'
+- Files now have filenames as well as titles, using the title for display where
+  possible
+
+
 1.4.0
 -----
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,8 +9,8 @@ Supported geoLink schema versions: v1.0.0, v1.1.0, v1.1.1, v1.2.0 (default)
 - Add support for geoLink schema version 1.2.0
 - New document attribute 'language'
 - New doctype 'notice'
-- Files now have filenames as well as titles, using the title for display where
-  possible
+- Files now have descriptions as well as titles, using the description for
+  display where possible
 
 
 1.4.0

--- a/geolink_formatter/__init__.py
+++ b/geolink_formatter/__init__.py
@@ -10,13 +10,13 @@ __version__ = '1.4.0'
 
 
 class GeoLinkFormatter(object):
-    def __init__(self, host_url=None, version='1.1.0', dtd_validation=False):
+    def __init__(self, host_url=None, version='1.2.0', dtd_validation=False):
         """Creates a new GeoLinkFormatter instance.
 
         Args:
             host_url (str): URL of the OEREBlex host to resolve relative URLs. The complete URL until but
                 without the */api* part has to be set, starting with *http://* or *https://*.
-            version (str): The version of the geoLink schema to be used. Defaults to `1.1.0`.
+            version (str): The version of the geoLink schema to be used. Defaults to `1.2.0`.
             dtd_validation (bool): Enable/disable validation of document type definition (DTD).
                 Optional, defaults to False.
 

--- a/geolink_formatter/entity.py
+++ b/geolink_formatter/entity.py
@@ -172,19 +172,21 @@ class Document(object):
 
 
 class File(object):
-    def __init__(self, category=None, href=None, title=None):
+    def __init__(self, category=None, href=None, title=None, filename=None):
         """Creates a new file instance.
 
         Args:
             category (str): The file's category.
             href (str): The URL to access the file.
             title (str): The file's title.
+            filename (str): The file's filename.
 
         """
 
         self._title = title
         self._href = href
         self._category = category
+        self._filename = filename
 
     @property
     def title(self):
@@ -200,3 +202,8 @@ class File(object):
     def category(self):
         """str: The file's category."""
         return self._category
+
+    @property
+    def filename(self):
+        """str: The file's filename."""
+        return self._filename

--- a/geolink_formatter/entity.py
+++ b/geolink_formatter/entity.py
@@ -172,21 +172,21 @@ class Document(object):
 
 
 class File(object):
-    def __init__(self, category=None, href=None, title=None, filename=None):
+    def __init__(self, category=None, href=None, title=None, description=None):
         """Creates a new file instance.
 
         Args:
             category (str): The file's category.
             href (str): The URL to access the file.
             title (str): The file's title.
-            filename (str): The file's filename.
+            description (str): The file's description.
 
         """
 
         self._title = title
         self._href = href
         self._category = category
-        self._filename = filename
+        self._description = description
 
     @property
     def title(self):
@@ -204,6 +204,6 @@ class File(object):
         return self._category
 
     @property
-    def filename(self):
-        """str: The file's filename."""
-        return self._filename
+    def description(self):
+        """str: The file's description."""
+        return self._description

--- a/geolink_formatter/format.py
+++ b/geolink_formatter/format.py
@@ -81,6 +81,9 @@ class HTML(object):
     def __format_file__(cls, file):
         """Formats a :obj:`geolink_formatter.entity.File` instance as HTML list item.
 
+        The name displayed is the title, falling back on the filename if no
+        title is present.
+
         Args:
             file (geolink_formatter.entity.File): The file to be formatted.
 
@@ -88,7 +91,11 @@ class HTML(object):
             str: The file formatted as HTML list item.
 
         """
+        title = file.title
+        if not title:
+            title = file.filename
+
         return u'<li class="geolink-formatter-file"><a href="{href}" target="_blank">{title}</a></li>'.format(
-            title=file.title,
+            title=title,
             href=file.href
         )

--- a/geolink_formatter/format.py
+++ b/geolink_formatter/format.py
@@ -32,6 +32,10 @@ class HTML(object):
             str: The document formatted as HTML list item.
 
         """
+        if document.enactment_date:
+            enactment_date = u'({0})'.format(document.enactment_date.strftime('%d.%m.%Y'))
+        else:
+            enactment_date = u''
         if document.abrogation_date:
             files = u''
             strike_start = u'<strike>'
@@ -44,12 +48,12 @@ class HTML(object):
             abrogation_date = u''
         subtype = u' ({0})'.format(document.subtype) if document.subtype else u''
         return u'<li class="geolink-formatter-document">' \
-               u'{strike_start}{type}{title} ({enactment_date}){strike_end} {abrogation_date}{files}' \
+               u'{strike_start}{type}{title} {enactment_date}{strike_end} {abrogation_date}{files}' \
                u'</li>'.format(
                    type=u'{0}{1}: '.format(document.type or u'', subtype)
                    if document.type or document.subtype else u'',
                    title=document.title,
-                   enactment_date=document.enactment_date.strftime('%d.%m.%Y'),
+                   enactment_date=enactment_date,
                    files=files,
                    strike_start=strike_start,
                    strike_end=strike_end,

--- a/geolink_formatter/format.py
+++ b/geolink_formatter/format.py
@@ -81,8 +81,8 @@ class HTML(object):
     def __format_file__(cls, file):
         """Formats a :obj:`geolink_formatter.entity.File` instance as HTML list item.
 
-        The name displayed is the title, falling back on the filename if no
-        title is present.
+        The name displayed is the description, falling back on the title
+        (containing the filename) if no description is present.
 
         Args:
             file (geolink_formatter.entity.File): The file to be formatted.
@@ -91,9 +91,9 @@ class HTML(object):
             str: The file formatted as HTML list item.
 
         """
-        title = file.title
+        title = file.description
         if not title:
-            title = file.filename
+            title = file.title
 
         return u'<li class="geolink-formatter-file"><a href="{href}" target="_blank">{title}</a></li>'.format(
             title=title,

--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -114,13 +114,9 @@ class XML(object):
                     href = file_el.attrib.get('href')
                     if self.host_url and not href.startswith(u'http://') and not href.startswith(u'https://'):
                         href = u'{host}{href}'.format(host=self.host_url, href=href)
-
-                    # NOTE: The XML attribute 'title' contains the filename in
-                    # truth, and the attribute 'description' is the true title
-                    # of the file (may be empty).
                     files.append(File(
-                        title=file_el.attrib.get('description'),
-                        filename=file_el.attrib.get('title'),
+                        title=file_el.attrib.get('title'),
+                        description=file_el.attrib.get('description'),
                         href=href,
                         category=file_el.attrib.get('category')
                     ))

--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -29,13 +29,13 @@ class XML(object):
     _date_format = '%Y-%m-%d'
     """str: Format of date values in XML."""
 
-    def __init__(self, host_url=None, version='1.1.1', dtd_validation=False, xsd_validation=True):
+    def __init__(self, host_url=None, version='1.2.0', dtd_validation=False, xsd_validation=True):
         """Create a new XML parser instance containing the geoLink XSD for validation.
 
         Args:
             host_url (str): URL of the OEREBlex host to resolve relative URLs. The complete URL until but
                 without the */api* part has to be set, starting with *http://* or *https://*.
-            version (str): The version of the geoLink schema to be used. Defaults to `1.1.1`.
+            version (str): The version of the geoLink schema to be used. Defaults to `1.2.0`.
             dtd_validation (bool): Enable/disable validation of document type definition (DTD).
                 Optional, defaults to False.
             xsd_validation (bool): Enable/disable validation against XML schema (XSD).

--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -101,6 +101,13 @@ class XML(object):
 
         for document_el in root.iter('document'):
             doc_id = document_el.attrib.get('id')
+            doctype = document_el.attrib.get('doctype')
+
+            # Mangle doc_id for notices. While IDs are unique between decrees
+            # and edicts, this is not the case when adding notices to the mix.
+            if doctype == 'notice':
+                doc_id += doctype
+
             if doc_id and doc_id not in [doc.id for doc in documents]:
                 files = list()
                 for file_el in document_el.iter('file'):

--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -114,9 +114,13 @@ class XML(object):
                     href = file_el.attrib.get('href')
                     if self.host_url and not href.startswith(u'http://') and not href.startswith(u'https://'):
                         href = u'{host}{href}'.format(host=self.host_url, href=href)
+
+                    # NOTE: The XML attribute 'title' contains the filename in
+                    # truth, and the attribute 'description' is the true title
+                    # of the file (may be empty).
                     files.append(File(
-                        title=file_el.attrib.get('title'),
-                        filename=file_el.attrib.get('filename'),
+                        title=file_el.attrib.get('description'),
+                        filename=file_el.attrib.get('title'),
                         href=href,
                         category=file_el.attrib.get('category')
                     ))

--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -20,6 +20,9 @@ class SCHEMA(object):
     V1_1_1 = '1.1.1'
     """str: geoLink schema version 1.1.1"""
 
+    V1_2_0 = '1.2.0'
+    """str: geoLink schema version 1.2.0"""
+
 
 class XML(object):
 

--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -116,6 +116,7 @@ class XML(object):
                         href = u'{host}{href}'.format(host=self.host_url, href=href)
                     files.append(File(
                         title=file_el.attrib.get('title'),
+                        filename=file_el.attrib.get('filename'),
                         href=href,
                         category=file_el.attrib.get('category')
                     ))

--- a/geolink_formatter/schema/v1.2.0.xsd
+++ b/geolink_formatter/schema/v1.2.0.xsd
@@ -1,0 +1,70 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="geolinks">
+        <xs:complexType>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:element name="document">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="file" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:attribute name="category">
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:enumeration value="main"/>
+                                                <xs:enumeration value="additional"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:attribute>
+                                    <xs:attribute name="href" type="xs:string"/>
+                                    <xs:attribute name="title" type="xs:string"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="id" type="xs:string"/>
+                        <xs:attribute name="category">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="main"/>
+                                    <xs:enumeration value="related"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:attribute>
+                        <xs:attribute name="doctype">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="edict"/>
+                                    <xs:enumeration value="decree"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:attribute>
+                        <xs:attribute name="federal_level">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="Bezirk"/>
+                                    <xs:enumeration value="Gemeinde"/>
+                                    <xs:enumeration value="Kanton"/>
+                                    <xs:enumeration value="Interkantonal"/>
+                                    <xs:enumeration value="Bund"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:attribute>
+                        <xs:attribute name="authority" type="xs:string"/>
+                        <xs:attribute name="authority_url" type="xs:string"/>
+                        <xs:attribute name="cycle" type="xs:string"/>
+                        <xs:attribute name="title" type="xs:string"/>
+                        <xs:attribute name="number" type="xs:string"/>
+                        <xs:attribute name="abbreviation" type="xs:string"/>
+                        <xs:attribute name="instance" type="xs:string"/>
+                        <xs:attribute name="type" type="xs:string"/>
+                        <xs:attribute name="subtype" type="xs:string"/>
+                        <xs:attribute name="decree_date" type="xs:string"/>
+                        <xs:attribute name="enactment_date" type="xs:string"/>
+                        <xs:attribute name="abrogation_date" type="xs:string"/>
+                        <xs:attribute name="approval_date" type="xs:string"/>
+                        <xs:attribute name="publication_date" type="xs:string"/>
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/geolink_formatter/schema/v1.2.0.xsd
+++ b/geolink_formatter/schema/v1.2.0.xsd
@@ -15,7 +15,7 @@
                                             </xs:restriction>
                                         </xs:simpleType>
                                     </xs:attribute>
-                                    <xs:attribute name="filename" type="xs:string"/>
+                                    <xs:attribute name="description" type="xs:string"/>
                                     <xs:attribute name="href" type="xs:string"/>
                                     <xs:attribute name="title" type="xs:string"/>
                                 </xs:complexType>

--- a/geolink_formatter/schema/v1.2.0.xsd
+++ b/geolink_formatter/schema/v1.2.0.xsd
@@ -34,6 +34,7 @@
                                 <xs:restriction base="xs:string">
                                     <xs:enumeration value="edict"/>
                                     <xs:enumeration value="decree"/>
+                                    <xs:enumeration value="notice"/>
                                 </xs:restriction>
                             </xs:simpleType>
                         </xs:attribute>

--- a/geolink_formatter/schema/v1.2.0.xsd
+++ b/geolink_formatter/schema/v1.2.0.xsd
@@ -49,6 +49,16 @@
                                 </xs:restriction>
                             </xs:simpleType>
                         </xs:attribute>
+                        <xs:attribute name="language">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="de"/>
+                                    <xs:enumeration value="fr"/>
+                                    <xs:enumeration value="it"/>
+                                    <xs:enumeration value="rm"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:attribute>
                         <xs:attribute name="authority" type="xs:string"/>
                         <xs:attribute name="authority_url" type="xs:string"/>
                         <xs:attribute name="cycle" type="xs:string"/>

--- a/geolink_formatter/schema/v1.2.0.xsd
+++ b/geolink_formatter/schema/v1.2.0.xsd
@@ -15,6 +15,7 @@
                                             </xs:restriction>
                                         </xs:simpleType>
                                     </xs:attribute>
+                                    <xs:attribute name="filename" type="xs:string"/>
                                     <xs:attribute name="href" type="xs:string"/>
                                     <xs:attribute name="title" type="xs:string"/>
                                 </xs:complexType>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def documents():
             title='Document with file',
             category='main',
             doctype='decree',
-            files=[File(title='Test file', filename='test.pdf',
+            files=[File(description='Test file', title='test.pdf',
                         href='http://www.example.com/test.pdf', category='main')],
             enactment_date=datetime.date(2017, 1, 15)
         )
@@ -45,7 +45,7 @@ def document_archived():
             title='Archived document',
             category='main',
             doctype='decree',
-            files=[File(title='Test file', filename='test.pdf',
+            files=[File(description='Test file', title='test.pdf',
                         href='http://www.example.com/test.pdf', category='main')],
             enactment_date=datetime.date(2017, 1, 15),
             abrogation_date=datetime.date(2019, 1, 1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,8 @@ def documents():
             title='Document with file',
             category='main',
             doctype='decree',
-            files=[File(title='Test file', href='http://www.example.com/test.pdf', category='main')],
+            files=[File(title='Test file', filename='test.pdf',
+                        href='http://www.example.com/test.pdf', category='main')],
             enactment_date=datetime.date(2017, 1, 15)
         )
     ]
@@ -44,7 +45,8 @@ def document_archived():
             title='Archived document',
             category='main',
             doctype='decree',
-            files=[File(title='Test file', href='http://www.example.com/test.pdf', category='main')],
+            files=[File(title='Test file', filename='test.pdf',
+                        href='http://www.example.com/test.pdf', category='main')],
             enactment_date=datetime.date(2017, 1, 15),
             abrogation_date=datetime.date(2019, 1, 1)
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def document_archived():
 @contextmanager
 def _mock_request():
     with requests_mock.mock() as m:
-        with open('tests/resources/geolink_v1.1.1.xml', 'rb') as f:
+        with open('tests/resources/geolink_v1.2.0.xml', 'rb') as f:
             m.get('http://oereblex.test.com/api/geolinks/1500.xml', content=f.read())
         yield m
 

--- a/tests/resources/geolink_v1.2.0.xml
+++ b/tests/resources/geolink_v1.2.0.xml
@@ -35,4 +35,7 @@
               title="700.1.pdf"></file>
 
     </document>
+    <document category="related" doctype="notice" id="4" title="Beispiel Hinweis Dokument">
+        <file category="main" href="/api/attachments/5101" title="example_notice.pdf"></file>
+    </document>
 </geolinks>

--- a/tests/resources/geolink_v1.2.0.xml
+++ b/tests/resources/geolink_v1.2.0.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<geolinks>
+    <document authority="Bauverwaltung Gemeinde" authority_url="http%3A%2F%2Fwww.zihlschlacht-sitterdorf.ch"
+              category="main" doctype="decree" enactment_date="2001-03-27"
+              federal_level="Gemeinde" id="1500" instance="DBU" subtype="Gestaltungsplan"
+              title="Tiefkühllager" type="Sondernutzungsplan" decree_date="2001-03-15" number="1A"
+              abbreviation="abbr">
+        <file category="main" href="/api/attachments/4735" title="2918-E-1.pdf"></file>
+        <file category="additional" href="/api/attachments/4736" title="2918-P-1.pdf"></file>
+        <file category="additional" href="/api/attachments/4737" title="2918-P-2.pdf"></file>
+        <file category="additional" href="/api/attachments/4738" title="2918-P-3.pdf"></file>
+        <file category="additional" href="/api/attachments/4739" title="2918-S-1.pdf"></file>
+
+    </document>
+    <document authority="Staatskanzlei Kanton Thurgau" authority_url="http%3A%2F%2Fwww.staatskanzlei.tg.ch"
+              category="related" decree_date="2011-12-21" doctype="edict" enactment_date="2017-04-01"
+              federal_level="Kanton" id="4782" title="Planungs- und Baugesetz">
+        <file category="main"
+              href="http://www.rechtsbuch.tg.ch/frontend/versions/pdf_file_with_annex/1379?locale=de"
+              title="700.pdf"></file>
+
+    </document>
+    <document authority="Bundeskanzlei" authority_url="https%3A%2F%2Fwww.bk.admin.ch" category="related"
+              doctype="edict" enactment_date="2016-01-01" federal_level="Bund" id="4776"
+              title="Bundesgesetz über die Raumplanung">
+        <file category="main" href="http://www.lexfind.ch/dtah/136884/2" title="700.de.pdf"></file>
+
+    </document>
+    <document authority="Staatskanzlei Kanton Thurgau" authority_url="http%3A%2F%2Fwww.staatskanzlei.tg.ch"
+              category="related" decree_date="2012-09-18" doctype="edict" enactment_date="2016-11-05"
+              federal_level="Kanton" id="4783"
+              title="Verordnung des Regierungsrates zum Planungs- und Baugesetz und zur Interkantonalen Vereinbarung über die Harmonisierung der Baubegriffe">
+        <file category="main"
+              href="http://www.rechtsbuch.tg.ch/frontend/versions/pdf_file_with_annex/1319?locale=de"
+              title="700.1.pdf"></file>
+
+    </document>
+</geolinks>

--- a/tests/resources/geolink_v1.2.0.xml
+++ b/tests/resources/geolink_v1.2.0.xml
@@ -5,11 +5,11 @@
               federal_level="Gemeinde" id="1500" instance="DBU" subtype="Gestaltungsplan"
               title="Tiefkühllager" type="Sondernutzungsplan" decree_date="2001-03-15" number="1A"
               abbreviation="abbr">
-        <file category="main" href="/api/attachments/4735" title="2918-E-1.pdf"></file>
-        <file category="additional" href="/api/attachments/4736" title="2918-P-1.pdf"></file>
-        <file category="additional" href="/api/attachments/4737" title="2918-P-2.pdf"></file>
-        <file category="additional" href="/api/attachments/4738" title="2918-P-3.pdf"></file>
-        <file category="additional" href="/api/attachments/4739" title="2918-S-1.pdf"></file>
+        <file category="main" href="/api/attachments/4735" filename="2918-E-1.pdf" title="2918-E-1.pdf"></file>
+        <file category="additional" href="/api/attachments/4736" filename="2918-P-1.pdf" title="Plan 1"></file>
+        <file category="additional" href="/api/attachments/4737" filename="2918-P-2.pdf" title="Plan 2"></file>
+        <file category="additional" href="/api/attachments/4738" filename="2918-P-3.pdf" title="Plan 3"></file>
+        <file category="additional" href="/api/attachments/4739" filename="2918-S-1.pdf" title=""></file>
 
     </document>
     <document authority="Staatskanzlei Kanton Thurgau" authority_url="http%3A%2F%2Fwww.staatskanzlei.tg.ch"
@@ -17,13 +17,14 @@
               federal_level="Kanton" id="4782" title="Planungs- und Baugesetz">
         <file category="main"
               href="http://www.rechtsbuch.tg.ch/frontend/versions/pdf_file_with_annex/1379?locale=de"
+              filename="700.pdf"
               title="700.pdf"></file>
 
     </document>
     <document authority="Bundeskanzlei" authority_url="https%3A%2F%2Fwww.bk.admin.ch" category="related"
               doctype="edict" enactment_date="2016-01-01" federal_level="Bund" id="4776"
               title="Bundesgesetz über die Raumplanung">
-        <file category="main" href="http://www.lexfind.ch/dtah/136884/2" title="700.de.pdf"></file>
+        <file category="main" href="http://www.lexfind.ch/dtah/136884/2" filename="700.de.pdf" title="700.de.pdf"></file>
 
     </document>
     <document authority="Staatskanzlei Kanton Thurgau" authority_url="http%3A%2F%2Fwww.staatskanzlei.tg.ch"
@@ -32,10 +33,11 @@
               title="Verordnung des Regierungsrates zum Planungs- und Baugesetz und zur Interkantonalen Vereinbarung über die Harmonisierung der Baubegriffe">
         <file category="main"
               href="http://www.rechtsbuch.tg.ch/frontend/versions/pdf_file_with_annex/1319?locale=de"
+              filename="700.1.pdf"
               title="700.1.pdf"></file>
 
     </document>
     <document category="related" doctype="notice" id="4" title="Beispiel Hinweis Dokument">
-        <file category="main" href="/api/attachments/5101" title="example_notice.pdf"></file>
+        <file category="main" href="/api/attachments/5101" filename="example_notice.pdf" title="example_notice.pdf"></file>
     </document>
 </geolinks>

--- a/tests/resources/geolink_v1.2.0.xml
+++ b/tests/resources/geolink_v1.2.0.xml
@@ -5,11 +5,11 @@
               federal_level="Gemeinde" id="1500" instance="DBU" subtype="Gestaltungsplan"
               title="Tiefkühllager" type="Sondernutzungsplan" decree_date="2001-03-15" number="1A"
               abbreviation="abbr">
-        <file category="main" href="/api/attachments/4735" filename="2918-E-1.pdf" title="2918-E-1.pdf"></file>
-        <file category="additional" href="/api/attachments/4736" filename="2918-P-1.pdf" title="Plan 1"></file>
-        <file category="additional" href="/api/attachments/4737" filename="2918-P-2.pdf" title="Plan 2"></file>
-        <file category="additional" href="/api/attachments/4738" filename="2918-P-3.pdf" title="Plan 3"></file>
-        <file category="additional" href="/api/attachments/4739" filename="2918-S-1.pdf" title=""></file>
+        <file category="main" href="/api/attachments/4735" title="2918-E-1.pdf" description="2918-E-1.pdf"></file>
+        <file category="additional" href="/api/attachments/4736" title="2918-P-1.pdf" description="Plan 1"></file>
+        <file category="additional" href="/api/attachments/4737" title="2918-P-2.pdf" description="Plan 2"></file>
+        <file category="additional" href="/api/attachments/4738" title="2918-P-3.pdf" description="Plan 3"></file>
+        <file category="additional" href="/api/attachments/4739" title="2918-S-1.pdf" description=""></file>
 
     </document>
     <document authority="Staatskanzlei Kanton Thurgau" authority_url="http%3A%2F%2Fwww.staatskanzlei.tg.ch"
@@ -17,14 +17,14 @@
               federal_level="Kanton" id="4782" title="Planungs- und Baugesetz">
         <file category="main"
               href="http://www.rechtsbuch.tg.ch/frontend/versions/pdf_file_with_annex/1379?locale=de"
-              filename="700.pdf"
+              description="700.pdf"
               title="700.pdf"></file>
 
     </document>
     <document authority="Bundeskanzlei" authority_url="https%3A%2F%2Fwww.bk.admin.ch" category="related"
               doctype="edict" enactment_date="2016-01-01" federal_level="Bund" id="4776"
               title="Bundesgesetz über die Raumplanung">
-        <file category="main" href="http://www.lexfind.ch/dtah/136884/2" filename="700.de.pdf" title="700.de.pdf"></file>
+        <file category="main" href="http://www.lexfind.ch/dtah/136884/2" description="700.de.pdf" title="700.de.pdf"></file>
 
     </document>
     <document authority="Staatskanzlei Kanton Thurgau" authority_url="http%3A%2F%2Fwww.staatskanzlei.tg.ch"
@@ -33,11 +33,11 @@
               title="Verordnung des Regierungsrates zum Planungs- und Baugesetz und zur Interkantonalen Vereinbarung über die Harmonisierung der Baubegriffe">
         <file category="main"
               href="http://www.rechtsbuch.tg.ch/frontend/versions/pdf_file_with_annex/1319?locale=de"
-              filename="700.1.pdf"
+              description="700.1.pdf"
               title="700.1.pdf"></file>
 
     </document>
     <document category="related" doctype="notice" id="4" title="Beispiel Hinweis Dokument">
-        <file category="main" href="/api/attachments/5101" filename="example_notice.pdf" title="example_notice.pdf"></file>
+        <file category="main" href="/api/attachments/5101" description="example_notice.pdf" title="example_notice.pdf"></file>
     </document>
 </geolinks>

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -27,8 +27,8 @@ def test_file_empty():
 def test_document():
     date = datetime.date.today()
     d = Document(id='1', title='Test', category='test', doctype='testdoc',
-                 files=[File('test.pdf', 'http://my.link.to/file', 'test')], enactment_date=date,
-                 federal_level='testlevel', authority='Authority',
+                 files=[File('TestCategory', 'http://my.link.to/file', 'Test Title', 'test.pdf')],
+                 enactment_date=date, federal_level='testlevel', authority='Authority',
                  authority_url='http://my.link.to/authority', type='testtype', subtype='testsubtype',
                  decree_date=date, instance='INST', number='123', abbreviation='abbr', abrogation_date=date,
                  cycle='cycle')

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -7,12 +7,12 @@ from geolink_formatter.entity import File, Document
 
 
 def test_file():
-    f = File(title='File title', href='http://my.link.to/file', category='test', filename='test.pdf')
+    f = File(description='File title', href='http://my.link.to/file', category='test', title='test.pdf')
     assert isinstance(f, File)
-    assert f.title == 'File title'
+    assert f.description == 'File title'
     assert f.href == 'http://my.link.to/file'
     assert f.category == 'test'
-    assert f.filename == 'test.pdf'
+    assert f.title == 'test.pdf'
 
 
 def test_file_empty():
@@ -21,7 +21,7 @@ def test_file_empty():
     assert f.title is None
     assert f.href is None
     assert f.category is None
-    assert f.filename is None
+    assert f.description is None
 
 
 def test_document():

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -7,11 +7,12 @@ from geolink_formatter.entity import File, Document
 
 
 def test_file():
-    f = File(title='test.pdf', href='http://my.link.to/file', category='test')
+    f = File(title='File title', href='http://my.link.to/file', category='test', filename='test.pdf')
     assert isinstance(f, File)
-    assert f.title == 'test.pdf'
+    assert f.title == 'File title'
     assert f.href == 'http://my.link.to/file'
     assert f.category == 'test'
+    assert f.filename == 'test.pdf'
 
 
 def test_file_empty():
@@ -20,6 +21,7 @@ def test_file_empty():
     assert f.title is None
     assert f.href is None
     assert f.category is None
+    assert f.filename is None
 
 
 def test_document():

--- a/tests/test_geolink_formatter.py
+++ b/tests/test_geolink_formatter.py
@@ -97,6 +97,7 @@ def test_html_url(mock_request):
                    u'</li>' \
                    u'</ul>'
 
+
 def test_html_invalid_source():
     with pytest.raises(TypeError):
         GeoLinkFormatter().html(1)

--- a/tests/test_geolink_formatter.py
+++ b/tests/test_geolink_formatter.py
@@ -87,8 +87,15 @@ def test_html_url(mock_request):
                    u'</li>' \
                    u'</ul>' \
                    u'</li>' \
+                   u'<li class="geolink-formatter-document">' \
+                   u'Beispiel Hinweis Dokument  ' \
+                   u'<ul class="geolink-formatter">' \
+                   u'<li class="geolink-formatter-file">' \
+                   u'<a href="/api/attachments/5101" target="_blank">example_notice.pdf</a>' \
+                   u'</li>' \
+                   u'</ul>' \
+                   u'</li>' \
                    u'</ul>'
-
 
 def test_html_invalid_source():
     with pytest.raises(TypeError):

--- a/tests/test_geolink_formatter.py
+++ b/tests/test_geolink_formatter.py
@@ -47,13 +47,13 @@ def test_html_url(mock_request):
                    u'<a href="/api/attachments/4735" target="_blank">2918-E-1.pdf</a>' \
                    u'</li>' \
                    u'<li class="geolink-formatter-file">' \
-                   u'<a href="/api/attachments/4736" target="_blank">2918-P-1.pdf</a>' \
+                   u'<a href="/api/attachments/4736" target="_blank">Plan 1</a>' \
                    u'</li>' \
                    u'<li class="geolink-formatter-file">' \
-                   u'<a href="/api/attachments/4737" target="_blank">2918-P-2.pdf</a>' \
+                   u'<a href="/api/attachments/4737" target="_blank">Plan 2</a>' \
                    u'</li>' \
                    u'<li class="geolink-formatter-file">' \
-                   u'<a href="/api/attachments/4738" target="_blank">2918-P-3.pdf</a>' \
+                   u'<a href="/api/attachments/4738" target="_blank">Plan 3</a>' \
                    u'</li>' \
                    u'<li class="geolink-formatter-file">' \
                    u'<a href="/api/attachments/4739" target="_blank">2918-S-1.pdf</a>' \

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -142,7 +142,7 @@ def test_xml_from_url(mock_request):
     fmt = '%Y-%m-%d'
     with mock_request():
         documents = XML().from_url('http://oereblex.test.com/api/geolinks/1500.xml')
-        assert len(documents) == 4
+        assert len(documents) == 5
         assert len(documents[0].files) == 5
         assert documents[0].decree_date.strftime(fmt) == '2001-03-15'
 
@@ -207,7 +207,7 @@ def test_schema_version_1_1_1_with_bezirk():
 
 def test_default_version_with_locale():
     with requests_mock.mock() as m:
-        with open('tests/resources/geolink_v1.1.1.xml', 'rb') as f:
+        with open('tests/resources/geolink_v1.2.0.xml', 'rb') as f:
             m.get('http://oereblex.test.com/api/geolinks/1500.xml?locale=fr', content=f.read())
         documents = XML().from_url('http://oereblex.test.com/api/geolinks/1500.xml', {'locale': 'fr'})
     assert documents[0].number == '1A'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -63,8 +63,10 @@ def test_xml_from_string(host_url):
                   federal_level='Gemeinde' id='1' subtype='Example Subtype' title='Example'
                   type='Example Type' decree_date='1999-11-01'>
             <file category='main' href='/api/attachments/1' title='example1.pdf'></file>
-            <file category='additional' href='/api/attachments/2' title='example2.pdf'></file>
-            <file category='additional' href='/api/attachments/3' title='example3.pdf'></file>
+            <file category='additional' href='/api/attachments/2'
+                  title='Example File' filename='example2.pdf'></file>
+            <file category='additional' href='/api/attachments/3'
+                  title='Example 2' filename='example3.pdf'></file>
         </document>
         <document authority='Another authority' authority_url='http://www.example.com' category='related'
                   doctype='edict' enactment_date='2016-01-01' federal_level='Bund' id='2'
@@ -92,7 +94,8 @@ def test_xml_from_string(host_url):
     assert documents[0].decree_date.month == 11
     assert documents[0].decree_date.day == 1
     assert len(documents[0].files) == 3
-    assert documents[0].files[1].title == 'example2.pdf'
+    assert documents[0].files[1].title == 'Example File'
+    assert documents[0].files[1].filename == 'example2.pdf'
     if host_url:
         assert documents[0].files[1].href == 'http://oereblex.test.com/api/attachments/2'
     else:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -94,8 +94,8 @@ def test_xml_from_string(host_url):
     assert documents[0].decree_date.month == 11
     assert documents[0].decree_date.day == 1
     assert len(documents[0].files) == 3
-    assert documents[0].files[1].title == 'Example File'
-    assert documents[0].files[1].filename == 'example2.pdf'
+    assert documents[0].files[1].description == 'Example File'
+    assert documents[0].files[1].title == 'example2.pdf'
     if host_url:
         assert documents[0].files[1].href == 'http://oereblex.test.com/api/attachments/2'
     else:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -182,6 +182,17 @@ def test_schema_version_1_1_1():
     assert documents[0].abrogation_date is None
 
 
+def test_schema_version_1_2_0():
+    with requests_mock.mock() as m:
+        with open('tests/resources/geolink_v1.2.0.xml', 'rb') as f:
+            m.get('http://oereblex.test.com/api/geolinks/1500.xml', content=f.read())
+        documents = XML(version=SCHEMA.V1_2_0).from_url('http://oereblex.test.com/api/geolinks/1500.xml')
+    assert len(documents) == 5
+    assert documents[-1].doctype == 'notice'
+    assert documents[-1].category == 'related'
+    assert len(documents[-1].files) == 1
+
+
 def test_schema_version_1_1_1_with_bezirk():
     fmt = '%Y-%m-%d'
     with requests_mock.mock() as m:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -64,9 +64,9 @@ def test_xml_from_string(host_url):
                   type='Example Type' decree_date='1999-11-01'>
             <file category='main' href='/api/attachments/1' title='example1.pdf'></file>
             <file category='additional' href='/api/attachments/2'
-                  title='Example File' filename='example2.pdf'></file>
+                  description='Example File' title='example2.pdf'></file>
             <file category='additional' href='/api/attachments/3'
-                  title='Example 2' filename='example3.pdf'></file>
+                  description='Example 2' title='example3.pdf'></file>
         </document>
         <document authority='Another authority' authority_url='http://www.example.com' category='related'
                   doctype='edict' enactment_date='2016-01-01' federal_level='Bund' id='2'


### PR DESCRIPTION
With the upcoming release of OEREBlex, targeted towards the end of 2019, the following additions are made to the API XML response:

- New `doctype` "notice" for additional documents that are not legally binding. In German: "weitere Informationen und Hinweise"
- New attribute `language` for every `document`, which is set to the ISO short code corresponding to the language of the document contents (title, files, etc.).

This pull request aims to facilitate the adoption of the new API version as soon as it becomes available. As the new API response is still subject to change, it might be advisable to not immediately merge this pull request but wait until the API 1.2.0 is stable. That way I can update the PR in accordance with the subsequent modifications.

I would like you to review my changes, especially the one concerning the `doc_id` in the list of documents that the parser returns. It may well be that there are downstream implications that render this approach unviable. In that case, please advise how to handle this new case of `document` elements without the `id` attribute.