### PR TITLE
Parse the schema only when needed

### DIFF
--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -47,8 +47,9 @@ class XML(object):
         self._dtd_validation = dtd_validation
         self._xsd_validation = xsd_validation
         xsd = pkg_resources.resource_filename('geolink_formatter', 'schema/v{0}.xsd'.format(version))
-        with open(xsd) as f:
-            self._schema = XMLSchema(fromstring(f.read()))
+        if self._xsd_validation:
+            with open(xsd) as f:
+                self._schema = XMLSchema(fromstring(f.read()))
 
     @property
     def host_url(self):


### PR DESCRIPTION
Parse the XML schema only if it is needed. This is more efficient, and avoids any errors in reading the XML schema if the schema is not needed anyway.

Note that this partially addresses issue #88 (it does not fix the issue, but if the user does not want XSD validation, the user will not be blocked by that issue).