### PR TITLE
Fix decoding error for new schema

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.5.3
+-----
+
+Supported geoLink schema versions: v1.0.0, v1.1.0, v1.1.1, v1.2.0 (default)
+
+- Fix decoding error for schema version 1.2.0
+
 1.5.2
 -----
 

--- a/geolink_formatter/__init__.py
+++ b/geolink_formatter/__init__.py
@@ -6,7 +6,7 @@ from geolink_formatter.format import HTML
 from geolink_formatter.parser import XML
 
 
-__version__ = '1.5.2'
+__version__ = '1.5.3'
 
 
 class GeoLinkFormatter(object):

--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -48,7 +48,7 @@ class XML(object):
         self._xsd_validation = xsd_validation
         xsd = pkg_resources.resource_filename('geolink_formatter', 'schema/v{0}.xsd'.format(version))
         if self._xsd_validation:
-            with open(xsd) as f:
+            with open(xsd, encoding='utf-8') as f:
                 self._schema = XMLSchema(fromstring(f.read()))
 
     @property

--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -3,6 +3,7 @@ import datetime
 
 import pkg_resources
 import requests
+import sys
 from lxml.etree import XMLSchema, DTD, DocumentInvalid
 from defusedxml.lxml import fromstring
 from geolink_formatter.entity import Document, File
@@ -48,8 +49,12 @@ class XML(object):
         self._xsd_validation = xsd_validation
         xsd = pkg_resources.resource_filename('geolink_formatter', 'schema/v{0}.xsd'.format(version))
         if self._xsd_validation:
-            with open(xsd, encoding='utf-8') as f:
-                self._schema = XMLSchema(fromstring(f.read()))
+            if sys.version_info.major > 2:
+                with open(xsd, encoding='utf-8') as f:
+                    self._schema = XMLSchema(fromstring(f.read()))
+            else:
+                with open(xsd) as f:
+                    self._schema = XMLSchema(fromstring(f.read()))
 
     @property
     def host_url(self):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requires = [
 ]
 
 setup(name='geolink_formatter',
-      version='1.5.2',
+      version='1.5.3',
       description='OEREBlex geoLink Formatter',
       license='BSD',
       long_description='{readme}\n\n{changelog}'.format(readme=readme, changelog=changelog),


### PR DESCRIPTION
Fix #88 

This is necessary for runtime environments which are not using utf-8, and starting oereblex API version 1.2.0.