### PR TITLE
add support for oereblex api version 1.2.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,10 @@
-Changelog
-=========
+Change log
+==========
 
 unreleased
 ----------
 
-Supported GEO-Link API versions: v1.0.0, v1.1.0, v1.1.1, v1.2.0, v1.2.1, v1.2.2, v1.2.3, v1.2.4 (default)
+Supported GEO-Link API versions: v1.0.0, v1.1.0, v1.1.1, v1.2.0, v1.2.1, v1.2.2, v1.2.3, v1.2.4, v1.2.5 (default)
 
 - Drop support for Python 3.8
 - Dependency updates

--- a/geolink_formatter/entity.py
+++ b/geolink_formatter/entity.py
@@ -13,7 +13,7 @@ class Document(object):
                  authority_url=None, title=None, number=None, abbreviation=None, instance=None, type=None,
                  subtype=None, decree_date=None, enactment_date=None, abrogation_date=None, cycle=None,
                  municipality=None, index=None, status=None, status_start_date=None, status_end_date=None,
-                 language=None, language_link=None):
+                 language_document=None, language_link=None):
         """Creates a new document instance.
 
         Args:
@@ -39,7 +39,7 @@ class Document(object):
             status (str or None): The status of the prebublication.
             status_start_date (datetime.date or None): Start date of the status.
             status_end_date (datetime.date or None): End date of the status.
-            language (str or None): Language of the document.
+            language_document (str or None): Language of the document.
             language_link (str or None): Language of the geolink/prepublink collection.
 
         Raises:
@@ -112,7 +112,7 @@ class Document(object):
         self._status = status
         self._status_start_date = status_start_date
         self._status_end_date = status_end_date
-        self._language = language
+        self._language_document = language_document
         self._language_link = language_link
 
     @property
@@ -226,9 +226,9 @@ class Document(object):
         return self._status_end_date
 
     @property
-    def language(self):
+    def language_document(self):
         """str: Language of the document (since v1.2.5)."""
-        return self._language
+        return self._language_document
 
     @property
     def language_link(self):

--- a/geolink_formatter/entity.py
+++ b/geolink_formatter/entity.py
@@ -12,7 +12,8 @@ class Document(object):
     def __init__(self, files, id=None, category=None, doctype=None, federal_level=None, authority=None,
                  authority_url=None, title=None, number=None, abbreviation=None, instance=None, type=None,
                  subtype=None, decree_date=None, enactment_date=None, abrogation_date=None, cycle=None,
-                 municipality=None, index=None, status=None, status_start_date=None, status_end_date=None):
+                 municipality=None, index=None, status=None, status_start_date=None, status_end_date=None,
+                 language=None, language_link=None):
         """Creates a new document instance.
 
         Args:
@@ -38,6 +39,8 @@ class Document(object):
             status (str or None): The status of the prebublication.
             status_start_date (datetime.date or None): Start date of the status.
             status_end_date (datetime.date or None): End date of the status.
+            language (str or None): Language of the document.
+            language_link (str or None): Language of the geolink/prepublink collection.
 
         Raises:
             TypeError: Raised on missing argument or invalid argument type.
@@ -109,6 +112,8 @@ class Document(object):
         self._status = status
         self._status_start_date = status_start_date
         self._status_end_date = status_end_date
+        self._language = language
+        self._language_link = language_link
 
     @property
     def files(self):
@@ -219,6 +224,16 @@ class Document(object):
     def status_end_date(self):
         """datetime.date: End date of the status (since v1.2.2)."""
         return self._status_end_date
+
+    @property
+    def language(self):
+        """str: Language of the document (since v1.2.5)."""
+        return self._language
+
+    @property
+    def language_link(self):
+        """str: Language of the geolink or prepublink (since v1.2.5)."""
+        return self._language_link
 
 
 class File(object):

--- a/geolink_formatter/entity.py
+++ b/geolink_formatter/entity.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+""" Provides the Msg, Document and File classes. """
 import datetime
 
 

--- a/geolink_formatter/format.py
+++ b/geolink_formatter/format.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+""" Provides class HTML for rendering the xml document from the geolink api as html. """
 from datetime import date
 
 

--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -169,7 +169,7 @@ class XML(object):
             status=document_el.attrib.get('status'),
             status_start_date=status_start_date,
             status_end_date=status_end_date,
-            language=document_el.attrib.get('language'),
+            language_document=document_el.attrib.get('language'),
             language_link=language_link
         )
 

--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
+""" Provides classes for parsing the xml document from the geolink api.  """
+from importlib import resources as impresources
 import datetime
 import requests
-import importlib
 from lxml.etree import DTD, DocumentInvalid, fromstring
 from xmlschema import XMLSchema11
 from geolink_formatter.entity import Document, File
@@ -61,7 +62,7 @@ class XML(object):
         self._version = version
         self._dtd_validation = dtd_validation
         self._xsd_validation = xsd_validation
-        xsd = importlib.resources.files('geolink_formatter') / 'schema' / f'v{version}.xsd'
+        xsd = impresources.files('geolink_formatter') / 'schema' / f'v{version}.xsd'
         if self._xsd_validation:
             with xsd.open(mode='r', encoding='utf-8') as xsd_f:
                 self._schema = XMLSchema11(xsd_f.read())
@@ -121,7 +122,7 @@ class XML(object):
         files = []
         for file_el in document_el.iter('file'):
             href = file_el.attrib.get('href')
-            if self.host_url and not href.startswith(u'http://') and not href.startswith('https://'):
+            if self.host_url and not href.startswith('http://') and not href.startswith('https://'):
                 href = f'{self.host_url}{href}'
             files.append(File(
                 title=file_el.attrib.get('title'),

--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
-import pkg_resources
+from importlib import resources
 import requests
 from lxml.etree import DTD, DocumentInvalid, fromstring
 from xmlschema import XMLSchema11
@@ -32,7 +32,10 @@ class SCHEMA(object):
     """str: geoLink schema version 1.2.3"""
 
     V1_2_4 = '1.2.4'
-    """str: geoLink schema version 1.2.3"""
+    """str: geoLink schema version 1.2.4"""
+
+    V1_2_5 = '1.2.5'
+    """str: geoLink schema version 1.2.5"""
 
 
 class XML(object):
@@ -40,7 +43,7 @@ class XML(object):
     _date_format = '%Y-%m-%d'
     """str: Format of date values in XML."""
 
-    def __init__(self, host_url=None, version='1.2.4', dtd_validation=False, xsd_validation=True):
+    def __init__(self, host_url=None, version='1.2.5', dtd_validation=False, xsd_validation=True):
         """Create a new XML parser instance containing the geoLink XSD for validation.
 
         Args:
@@ -57,9 +60,9 @@ class XML(object):
         self._version = version
         self._dtd_validation = dtd_validation
         self._xsd_validation = xsd_validation
-        xsd = pkg_resources.resource_filename('geolink_formatter', 'schema/v{0}.xsd'.format(version))
+        xsd = resources.files('geolink_formatter') / 'schema' / 'v{0}.xsd'.format(version)
         if self._xsd_validation:
-            with open(xsd, encoding='utf-8') as f:
+            with xsd.open(mode='r', encoding='utf-8') as f:
                 self._schema = XMLSchema11(f.read())
 
     @property
@@ -94,6 +97,123 @@ class XML(object):
                 raise DocumentInvalid('Missing DTD in parsed content')
         return content
 
+    def _process_single_document(self, document_el, language_link):
+        """
+        Processes a single document element.
+
+        Args:
+            document_el (lxml.etree._Element): element 'document'
+            language_link (str): language of the documents set
+
+        Returns:
+            geolink_formatter.entity.Document: document
+
+        """
+        doc_id = document_el.attrib.get('id')
+        doctype = document_el.attrib.get('doctype')
+
+        # Mangle doc_id for notices. While IDs are unique between decrees
+        # and edicts, this is not the case when adding notices to the mix.
+        if doctype == 'notice':
+            doc_id += doctype
+
+        files = list()
+        for file_el in document_el.iter('file'):
+            href = file_el.attrib.get('href')
+            if self.host_url and not href.startswith(u'http://') and not href.startswith(u'https://'):
+                href = u'{host}{href}'.format(host=self.host_url, href=href)
+            files.append(File(
+                title=file_el.attrib.get('title'),
+                description=file_el.attrib.get('description'),
+                href=href,
+                category=file_el.attrib.get('category')
+            ))
+        enactment_date = document_el.attrib.get('enactment_date')
+        if enactment_date:
+            enactment_date = datetime.datetime.strptime(enactment_date, self._date_format).date()
+        decree_date = document_el.attrib.get('decree_date')
+        if decree_date:
+            decree_date = datetime.datetime.strptime(decree_date, self._date_format).date()
+        abrogation_date = document_el.attrib.get('abrogation_date')
+        if abrogation_date:
+            abrogation_date = datetime.datetime.strptime(abrogation_date, self._date_format).date()
+        status_start_date = document_el.attrib.get('status_start_date')
+        if status_start_date:
+            status_start_date = datetime.datetime.strptime(status_start_date, self._date_format)\
+                                                    .date()
+        status_end_date = document_el.attrib.get('status_end_date')
+        if status_end_date:
+            status_end_date = datetime.datetime\
+                .strptime(status_end_date, self._date_format).date()
+
+        document = Document(
+            files=files,
+            id=doc_id,
+            category=document_el.attrib.get('category'),
+            doctype=document_el.attrib.get('doctype'),
+            federal_level=document_el.attrib.get('federal_level'),
+            authority=document_el.attrib.get('authority'),
+            authority_url=document_el.attrib.get('authority_url'),
+            title=document_el.attrib.get('title'),
+            number=document_el.attrib.get('number'),
+            abbreviation=document_el.attrib.get('abbreviation'),
+            instance=document_el.attrib.get('instance'),
+            type=document_el.attrib.get('type'),
+            subtype=document_el.attrib.get('subtype'),
+            decree_date=decree_date,
+            enactment_date=enactment_date,
+            abrogation_date=abrogation_date,
+            cycle=document_el.attrib.get('cycle'),
+            municipality=document_el.attrib.get('municipality'),
+            index=document_el.attrib.get('index'),
+            status=document_el.attrib.get('status'),
+            status_start_date=status_start_date,
+            status_end_date=status_end_date,
+            language=document_el.attrib.get('language'),
+            language_link=language_link
+        )
+
+        assert isinstance(document, Document)
+        assert document.id is not None
+
+        return document
+
+    def _process_geolinks_prepublinks(self, geolink_prepublink_el):
+        """
+        Processes a 'geolinks' or 'prepublinks' element.
+
+        Args:
+            geolink_prepublink_el (lxml.etree._Element): element 'geolinks' or 'prepublinks'
+
+        Return:
+            list[geolink_formatter.entity.Document]: list of documents
+        """
+        language_link = geolink_prepublink_el.get('language')
+
+        documents = list()
+        for document_el in geolink_prepublink_el.iter('document'):
+            documents.append(self._process_single_document(document_el, language_link))
+        return documents
+
+    def _filter_duplicated_documents(self, documents):
+        """
+        Filters duplicated documents.
+
+        Args:
+            documents (list[geolink_formatter.entity.Document]): list of documents
+
+        Returns:
+            list[geolink_formatter.entity.Document]: filtered list of documents
+        """
+        documents_filtered = list()
+        for document in documents:
+            if (
+                [document.id, document.language_link] not in
+                [[doc.id, doc.language_link] for doc in documents_filtered]
+            ):
+                documents_filtered.append(document)
+        return documents_filtered
+
     def from_string(self, xml):
         """Parses XML into internal structure.
 
@@ -111,70 +231,17 @@ class XML(object):
         root = self._parse_xml(xml)
         documents = list()
 
-        for document_el in root.iter('document'):
-            doc_id = document_el.attrib.get('id')
-            doctype = document_el.attrib.get('doctype')
+        # evaluate root element's tag
+        if root.tag == 'multilang_geolinks':
+            for el in root.iter('geolinks', 'prepublinks'):
+                documents.extend(self._process_geolinks_prepublinks(el))
+        elif root.tag in ['geolinks', 'prepublinks']:
+            documents.extend(self._process_geolinks_prepublinks(root))
+        else:
+            raise RuntimeError('Unexpected tag name: {}'.format(root.tag))
 
-            # Mangle doc_id for notices. While IDs are unique between decrees
-            # and edicts, this is not the case when adding notices to the mix.
-            if doctype == 'notice':
-                doc_id += doctype
-
-            if doc_id and doc_id not in [doc.id for doc in documents]:
-                files = list()
-                for file_el in document_el.iter('file'):
-                    href = file_el.attrib.get('href')
-                    if self.host_url and not href.startswith(u'http://') and not href.startswith(u'https://'):
-                        href = u'{host}{href}'.format(host=self.host_url, href=href)
-                    files.append(File(
-                        title=file_el.attrib.get('title'),
-                        description=file_el.attrib.get('description'),
-                        href=href,
-                        category=file_el.attrib.get('category')
-                    ))
-                enactment_date = document_el.attrib.get('enactment_date')
-                if enactment_date:
-                    enactment_date = datetime.datetime.strptime(enactment_date, self._date_format).date()
-                decree_date = document_el.attrib.get('decree_date')
-                if decree_date:
-                    decree_date = datetime.datetime.strptime(decree_date, self._date_format).date()
-                abrogation_date = document_el.attrib.get('abrogation_date')
-                if abrogation_date:
-                    abrogation_date = datetime.datetime.strptime(abrogation_date, self._date_format).date()
-                status_start_date = document_el.attrib.get('status_start_date')
-                if status_start_date:
-                    status_start_date = datetime.datetime.strptime(status_start_date, self._date_format)\
-                                                         .date()
-                status_end_date = document_el.attrib.get('status_end_date')
-                if status_end_date:
-                    status_end_date = datetime.datetime.strptime(status_end_date, self._date_format)\
-                                                        .date()
-
-                documents.append(Document(
-                    files=files,
-                    id=doc_id,
-                    category=document_el.attrib.get('category'),
-                    doctype=document_el.attrib.get('doctype'),
-                    federal_level=document_el.attrib.get('federal_level'),
-                    authority=document_el.attrib.get('authority'),
-                    authority_url=document_el.attrib.get('authority_url'),
-                    title=document_el.attrib.get('title'),
-                    number=document_el.attrib.get('number'),
-                    abbreviation=document_el.attrib.get('abbreviation'),
-                    instance=document_el.attrib.get('instance'),
-                    type=document_el.attrib.get('type'),
-                    subtype=document_el.attrib.get('subtype'),
-                    decree_date=decree_date,
-                    enactment_date=enactment_date,
-                    abrogation_date=abrogation_date,
-                    cycle=document_el.attrib.get('cycle'),
-                    municipality=document_el.attrib.get('municipality'),
-                    index=document_el.attrib.get('index'),
-                    status=document_el.attrib.get('status'),
-                    status_start_date=status_start_date,
-                    status_end_date=status_end_date
-                ))
-
+        # filter documents (remove duplicates)
+        documents = self._filter_duplicated_documents(documents)
         return documents
 
     def from_url(self, url, params=None, **kwargs):

--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -212,7 +212,7 @@ class XML(object):
         documents = []
 
         # evaluate root element's tag
-        if root.tag == 'multilang_geolinks':
+        if root.tag in ['multilang_geolinks', 'multilang_prepublinks']:
             for elem in root.iter('geolinks', 'prepublinks'):
                 documents.extend(self._process_geolinks_prepublinks(elem))
         elif root.tag in ['geolinks', 'prepublinks']:

--- a/geolink_formatter/schema/v1.2.5.xsd
+++ b/geolink_formatter/schema/v1.2.5.xsd
@@ -1,0 +1,113 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:element name="multilang_geolinks">
+    <xs:complexType>
+      <xs:choice minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="geolinks" type="base_links" />
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="geolinks" type="base_links" />
+
+  <xs:element name="multilang_prepublinks">
+    <xs:complexType>
+      <xs:choice minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="prepublinks" type="base_links" />
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="prepublinks" type="base_links" />
+
+  <xs:complexType name="base_links">
+    <xs:sequence>
+      <xs:element name="document" type="full_document" minOccurs="1" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute name="language" type="language" />
+  </xs:complexType>
+
+  <xs:complexType name="full_document">
+    <xs:complexContent>
+      <xs:extension base="base_document">
+        <xs:attributeGroup ref="geolink_document" />
+        <xs:attributeGroup ref="prepublink_document" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:attributeGroup name="geolink_document">
+    <xs:attribute name="abrogation_date" type="xs:date" />
+    <xs:attribute name="approval_date" type="xs:date" />
+    <xs:attribute name="decree_date" type="xs:date" />
+    <xs:attribute name="enactment_date" type="xs:date" />
+    <xs:attribute name="publication_date" type="xs:date" />
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="prepublink_document">
+    <xs:attribute name="status" type="xs:string" />
+    <xs:attribute name="status_end_date" type="xs:date" />
+    <xs:attribute name="status_start_date" type="xs:date" />
+  </xs:attributeGroup>
+
+  <xs:complexType name="base_document">
+    <xs:sequence>
+      <xs:element name="file" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:attribute name="category">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="main" />
+                <xs:enumeration value="additional" />
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="href" type="xs:string" />
+          <xs:attribute name="title" type="xs:string" />
+          <xs:attribute name="description" type="xs:string" />
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="abbreviation" type="xs:string" />
+    <xs:attribute name="authority" type="xs:string" />
+    <xs:attribute name="authority_url" type="xs:string" />
+    <xs:attribute name="category">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="main" />
+          <xs:enumeration value="related" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="cycle" type="xs:string" />
+    <xs:attribute name="doctype">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="edict" />
+          <xs:enumeration value="decree" />
+          <xs:enumeration value="notice" />
+          <xs:enumeration value="prepublication" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="federal_level" type="xs:string" />
+    <xs:attribute name="id" type="xs:string" />
+    <xs:attribute name="index" type="xs:integer" />
+    <xs:attribute name="instance" type="xs:string" />
+    <xs:attribute name="language" type="language" />
+    <xs:attribute name="municipality" type="xs:string" />
+    <xs:attribute name="number" type="xs:string" />
+    <xs:attribute name="subtype" type="xs:string" />
+    <xs:attribute name="title" type="xs:string" />
+    <xs:attribute name="type" type="xs:string" />
+  </xs:complexType>
+
+  <xs:simpleType name="language">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="de" />
+      <xs:enumeration value="fr" />
+      <xs:enumeration value="it" />
+      <xs:enumeration value="rm" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/geolink_formatter/utils.py
+++ b/geolink_formatter/utils.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+def filter_duplicated_documents(documents):
+    """
+    Filters duplicated documents.
+
+    Args:
+        documents (list[geolink_formatter.entity.Document]): list of documents
+
+    Returns:
+        list[geolink_formatter.entity.Document]: filtered list of documents
+    """
+    documents_filtered = list()
+    for document in documents:
+        if (
+                [document.id, document.language_link]
+                not in [[doc.id, doc.language_link] for doc in documents_filtered]
+        ):
+            documents_filtered.append(document)
+    return documents_filtered

--- a/geolink_formatter/utils.py
+++ b/geolink_formatter/utils.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+""" Provides additional methods usable for parsing the xml document from the geolink api. """
+
 
 def filter_duplicated_documents(documents):
     """
@@ -10,7 +12,7 @@ def filter_duplicated_documents(documents):
     Returns:
         list[geolink_formatter.entity.Document]: filtered list of documents
     """
-    documents_filtered = list()
+    documents_filtered = []
     for document in documents:
         if (
                 [document.id, document.language_link]

--- a/tests/resources/geolink_v1.2.5.xml
+++ b/tests/resources/geolink_v1.2.5.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<geolinks language='de'>
+    <document authority='Gemeindeverwaltung' authority_url='https://www.domleschg.ch'
+        category='main' doctype='decree' enactment_date='2012-06-22' federal_level='Gemeinde'
+        id='400' language='de' municipality='Domleschg' number='12.GDEf1'
+        subtype='Domleschg (Paspels) 3634' title='Quartierplan Radiend'
+        type='Nutzungsplanung - Quartierplanverfahren'>
+        <file category='main' description='3634_B_QP_Radiend_Platzhalter.pdf'
+            href='/api/attachments/1123' title='3634_B_QP_Radiend_Platzhalter.pdf'></file>
+        <file category='additional' description='' href='/api/attachments/6027'
+            title='PlatzhalterFehlendeDokumente.pdf'></file>
+
+    </document>
+    <document authority='Gemeindeverwaltung' authority_url='https://www.domleschg.ch'
+        category='related' doctype='decree' enactment_date='2006-09-19' federal_level='Gemeinde'
+        id='390' language='de' municipality='Domleschg' number='3634.(1)' title='Baugesetz Paspels'>
+        <file category='main' description='3634_V_Paspels_BauG.pdf' href='/api/attachments/17740'
+            title='3634_V_Paspels_BauG.pdf'></file>
+
+    </document>
+    <document abbreviation='KRG' authority='Standeskanzlei' authority_url='http://www.staka.gr.ch'
+        category='related' decree_date='2004-12-06' doctype='edict' enactment_date='2019-04-01'
+        federal_level='Kanton' id='17' index='1000' language='de' number='801.100'
+        title='Raumplanungsgesetz für den Kanton Graubünden'>
+        <file category='main' description='801.100.pdf'
+            href='https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3045?locale=de'
+            title='801.100.pdf'></file>
+
+    </document>
+    <document abbreviation='KRVO' authority='Standeskanzlei' authority_url='http://www.staka.gr.ch'
+        category='related' decree_date='2005-05-24' doctype='edict' enactment_date='2023-09-01'
+        federal_level='Kanton' id='18' index='1000' language='de' number='801.110'
+        title='Raumplanungsverordnung für den Kanton Graubünden'>
+        <file category='main' description='801.110.pdf'
+            href='https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3335?locale=de'
+            title='801.110.pdf'></file>
+
+    </document>
+    <document abbreviation='' authority='Standeskanzlei' authority_url='http://www.staka.gr.ch'
+        category='related' decree_date='1997-05-06' doctype='edict' enactment_date='2007-01-01'
+        federal_level='Kanton' id='34' index='1000' language='de' number='801.500'
+        title='Richtlinien für die Gefahrenzonenplanung'>
+        <file category='main' description='801.500.pdf'
+            href='https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2417?locale=de'
+            title='801.500.pdf'></file>
+
+    </document>
+    <document abbreviation='Kantonales Umweltschutzgesetz, KUSG' authority='Standeskanzlei'
+        authority_url='http://www.staka.gr.ch' category='related' decree_date='2001-12-02'
+        doctype='edict' enactment_date='2020-04-01' federal_level='Kanton' id='19' index='1000'
+        language='de' number='820.100'
+        title='Einführungsgesetz zum Bundesgesetz über den Umweltschutz'>
+        <file category='main' description='820.100.pdf'
+            href='https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3025?locale=de'
+            title='820.100.pdf'></file>
+
+    </document>
+    <document abbreviation='KWaG' authority='Standeskanzlei' authority_url='http://www.staka.gr.ch'
+        category='related' decree_date='2012-06-11' doctype='edict' enactment_date='2021-01-01'
+        federal_level='Kanton' id='23' index='1000' language='de' number='920.100'
+        title='Kantonales Waldgesetz'>
+        <file category='main' description='920.100.pdf'
+            href='https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3117?locale=de'
+            title='920.100.pdf'></file>
+
+    </document>
+    <document abbreviation='KWaV' authority='Standeskanzlei' authority_url='http://www.staka.gr.ch'
+        category='related' decree_date='2012-12-03' doctype='edict' enactment_date='2021-01-01'
+        federal_level='Kanton' id='24' index='1000' language='de' number='920.110'
+        title='Kantonale Waldverordnung'>
+        <file category='main' description='920.110.pdf'
+            href='https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3118?locale=de'
+            title='920.110.pdf'></file>
+
+    </document>
+    <document abbreviation='Raumplanungsgesetz, RPG' authority='Bundeskanzlei'
+        authority_url='https://www.bk.admin.ch/' category='related' doctype='edict'
+        enactment_date='2019-01-01' federal_level='Bund' id='5' index='10' language='de'
+        number='SR 700' title='Bundesgesetz über die Raumplanung'>
+        <file category='main' description='700.de.pdf' href='https://www.lexfind.ch/tolv/247302/de'
+            title='700.de.pdf'></file>
+
+    </document>
+    <document abbreviation='LSV' authority='Bundeskanzlei' authority_url='https://www.bk.admin.ch/'
+        category='related' doctype='edict' enactment_date='2024-11-01' federal_level='Bund' id='11'
+        index='620' language='de' number='SR 814.41' title='Lärmschutz-Verordnung'>
+        <file category='main' description='814.41.de.pdf'
+            href='https://www.lexfind.ch/tolv/247358/de' title='814.41.de.pdf'></file>
+
+    </document>
+    <document abbreviation='Waldgesetz, WaG' authority='Bundeskanzlei'
+        authority_url='https://www.bk.admin.ch/' category='related' doctype='edict'
+        enactment_date='2022-01-01' federal_level='Bund' id='13' index='710' language='de'
+        number='SR 921.0' title='Bundesgesetz über den Wald'>
+        <file category='main' description='921.0.de.pdf'
+            href='https://www.lexfind.ch/tolv/246994/de' title='921.0.de.pdf'></file>
+
+    </document>
+    <document abbreviation='Waldverordnung, WaV' authority='Bundeskanzlei'
+        authority_url='https://www.bk.admin.ch/' category='related' doctype='edict'
+        enactment_date='2021-07-01' federal_level='Bund' id='14' index='720' language='de'
+        number='SR 921.01' title='Verordnung über den Wald'>
+        <file category='main' description='921.01.de.pdf'
+            href='https://www.lexfind.ch/tolv/207456/de' title='921.01.de.pdf'></file>
+
+    </document>
+</geolinks>

--- a/tests/resources/geolink_v1.2.5_ml.xml
+++ b/tests/resources/geolink_v1.2.5_ml.xml
@@ -1,0 +1,336 @@
+<?xml version="1.0" encoding="utf-8"?>
+<multilang_geolinks>
+    <geolinks language="de">
+        <document authority="Gemeindeverwaltung" authority_url="https://www.domleschg.ch"
+            category="main" doctype="decree" enactment_date="2012-06-22" federal_level="Gemeinde"
+            id="400" language="de" municipality="Domleschg" number="12.GDEf1"
+            subtype="Domleschg (Paspels) 3634" title="Quartierplan Radiend"
+            type="Nutzungsplanung - Quartierplanverfahren">
+            <file category="main" description="3634_B_QP_Radiend_Platzhalter.pdf"
+                href="/api/attachments/1123" title="3634_B_QP_Radiend_Platzhalter.pdf" />
+            <file category="additional" description="" href="/api/attachments/6027"
+                title="PlatzhalterFehlendeDokumente.pdf" />
+
+        </document>
+        <document authority="Gemeindeverwaltung" authority_url="https://www.domleschg.ch"
+            category="related" doctype="decree" enactment_date="2006-09-19" federal_level="Gemeinde"
+            id="390" language="de" municipality="Domleschg" number="3634.(1)"
+            title="Baugesetz Paspels">
+            <file category="main" description="3634_V_Paspels_BauG.pdf"
+                href="/api/attachments/17740" title="3634_V_Paspels_BauG.pdf" />
+
+        </document>
+        <document abbreviation="KRG" authority="Standeskanzlei"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="2004-12-06"
+            doctype="edict" enactment_date="2019-04-01" federal_level="Kanton" id="17" index="1000"
+            language="de" number="801.100" title="Raumplanungsgesetz für den Kanton Graubünden">
+            <file category="main" description="801.100.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3045?locale=de"
+                title="801.100.pdf" />
+
+        </document>
+        <document abbreviation="KRVO" authority="Standeskanzlei"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="2005-05-24"
+            doctype="edict" enactment_date="2023-09-01" federal_level="Kanton" id="18" index="1000"
+            language="de" number="801.110" title="Raumplanungsverordnung für den Kanton Graubünden">
+            <file category="main" description="801.110.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3335?locale=de"
+                title="801.110.pdf" />
+
+        </document>
+        <document abbreviation="" authority="Standeskanzlei" authority_url="http://www.staka.gr.ch"
+            category="related" decree_date="1997-05-06" doctype="edict" enactment_date="2007-01-01"
+            federal_level="Kanton" id="34" index="1000" language="de" number="801.500"
+            title="Richtlinien für die Gefahrenzonenplanung">
+            <file category="main" description="801.500.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2417?locale=de"
+                title="801.500.pdf" />
+
+        </document>
+        <document abbreviation="Kantonales Umweltschutzgesetz, KUSG" authority="Standeskanzlei"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="2001-12-02"
+            doctype="edict" enactment_date="2020-04-01" federal_level="Kanton" id="19" index="1000"
+            language="de" number="820.100"
+            title="Einführungsgesetz zum Bundesgesetz über den Umweltschutz">
+            <file category="main" description="820.100.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3025?locale=de"
+                title="820.100.pdf" />
+
+        </document>
+        <document abbreviation="KWaG" authority="Standeskanzlei"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="2012-06-11"
+            doctype="edict" enactment_date="2021-01-01" federal_level="Kanton" id="23" index="1000"
+            language="de" number="920.100" title="Kantonales Waldgesetz">
+            <file category="main" description="920.100.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3117?locale=de"
+                title="920.100.pdf" />
+
+        </document>
+        <document abbreviation="KWaV" authority="Standeskanzlei"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="2012-12-03"
+            doctype="edict" enactment_date="2021-01-01" federal_level="Kanton" id="24" index="1000"
+            language="de" number="920.110" title="Kantonale Waldverordnung">
+            <file category="main" description="920.110.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3118?locale=de"
+                title="920.110.pdf" />
+
+        </document>
+        <document abbreviation="Raumplanungsgesetz, RPG" authority="Bundeskanzlei"
+            authority_url="https://www.bk.admin.ch/" category="related" doctype="edict"
+            enactment_date="2019-01-01" federal_level="Bund" id="5" index="10" language="de"
+            number="SR 700" title="Bundesgesetz über die Raumplanung">
+            <file category="main" description="700.de.pdf"
+                href="https://www.lexfind.ch/tolv/247302/de" title="700.de.pdf" />
+
+        </document>
+        <document abbreviation="LSV" authority="Bundeskanzlei"
+            authority_url="https://www.bk.admin.ch/" category="related" doctype="edict"
+            enactment_date="2024-11-01" federal_level="Bund" id="11" index="620" language="de"
+            number="SR 814.41" title="Lärmschutz-Verordnung">
+            <file category="main" description="814.41.de.pdf"
+                href="https://www.lexfind.ch/tolv/247358/de" title="814.41.de.pdf" />
+
+        </document>
+        <document abbreviation="Waldgesetz, WaG" authority="Bundeskanzlei"
+            authority_url="https://www.bk.admin.ch/" category="related" doctype="edict"
+            enactment_date="2022-01-01" federal_level="Bund" id="13" index="710" language="de"
+            number="SR 921.0" title="Bundesgesetz über den Wald">
+            <file category="main" description="921.0.de.pdf"
+                href="https://www.lexfind.ch/tolv/246994/de" title="921.0.de.pdf" />
+
+        </document>
+        <document abbreviation="Waldverordnung, WaV" authority="Bundeskanzlei"
+            authority_url="https://www.bk.admin.ch/" category="related" doctype="edict"
+            enactment_date="2021-07-01" federal_level="Bund" id="14" index="720" language="de"
+            number="SR 921.01" title="Verordnung über den Wald">
+            <file category="main" description="921.01.de.pdf"
+                href="https://www.lexfind.ch/tolv/207456/de" title="921.01.de.pdf" />
+
+        </document>
+    </geolinks>
+
+    <geolinks language="rm">
+        <document authority="administraziun communala" authority_url="https://www.domleschg.ch"
+            category="main" doctype="decree" enactment_date="2012-06-22" federal_level="Vischnanca"
+            id="400" language="de" municipality="Domleschg" number="12.GDEf1"
+            subtype="Domleschg (Paspels) 3634" title="Quartierplan Radiend"
+            type="planisaziun d'utilisaziun - procedura per il plan da quartier">
+            <file category="main" description="3634_B_QP_Radiend_Platzhalter.pdf"
+                href="/api/attachments/1123" title="3634_B_QP_Radiend_Platzhalter.pdf" />
+            <file category="additional" description="" href="/api/attachments/6027"
+                title="PlatzhalterFehlendeDokumente.pdf" />
+
+        </document>
+        <document authority="administraziun communala" authority_url="https://www.domleschg.ch"
+            category="related" doctype="decree" enactment_date="2006-09-19"
+            federal_level="Vischnanca" id="390" language="de" municipality="Domleschg"
+            number="3634.(1)" title="Baugesetz Paspels">
+            <file category="main" description="3634_V_Paspels_BauG.pdf"
+                href="/api/attachments/17740" title="3634_V_Paspels_BauG.pdf" />
+
+        </document>
+        <document abbreviation="LPTGR" authority="chanzlia chantunala"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="2004-12-06"
+            doctype="edict" enactment_date="2019-04-01" federal_level="Chantun" id="17" index="1000"
+            language="rm" number="801.100"
+            title="Lescha davart la planisaziun dal territori per il chantun Grischun">
+            <file category="main" description="801.100.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3045?locale=rm"
+                title="801.100.pdf" />
+
+        </document>
+        <document abbreviation="KRVO" authority="chanzlia chantunala"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="2005-05-24"
+            doctype="edict" enactment_date="2023-09-01" federal_level="Chantun" id="18" index="1000"
+            language="de" number="801.110" title="Raumplanungsverordnung für den Kanton Graubünden">
+            <file category="main" description="801.110.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3335?locale=rm"
+                title="801.110.pdf" />
+
+        </document>
+        <document abbreviation="" authority="chanzlia chantunala"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="1997-05-06"
+            doctype="edict" enactment_date="2007-01-01" federal_level="Chantun" id="34" index="1000"
+            language="rm" number="801.500"
+            title="Directivas per la planisaziun da las zonas da privel">
+            <file category="main" description="801.500.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2417?locale=rm"
+                title="801.500.pdf" />
+
+        </document>
+        <document abbreviation="lescha chantunala davart la protecziun da l'ambient, LCPAmb"
+            authority="chanzlia chantunala" authority_url="http://www.staka.gr.ch"
+            category="related" decree_date="2001-12-02" doctype="edict" enactment_date="2020-04-01"
+            federal_level="Chantun" id="19" index="1000" language="rm" number="820.100"
+            title="Lescha introductiva tar la lescha federala davart la protecziun da l'ambient">
+            <file category="main" description="820.100.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3025?locale=rm"
+                title="820.100.pdf" />
+
+        </document>
+        <document abbreviation="LCG" authority="chanzlia chantunala"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="2012-06-11"
+            doctype="edict" enactment_date="2021-01-01" federal_level="Chantun" id="23" index="1000"
+            language="rm" number="920.100" title="Lescha chantunala davart il guaud">
+            <file category="main" description="920.100.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3117?locale=rm"
+                title="920.100.pdf" />
+
+        </document>
+        <document abbreviation="OCG" authority="chanzlia chantunala"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="2012-12-03"
+            doctype="edict" enactment_date="2021-01-01" federal_level="Chantun" id="24" index="1000"
+            language="rm" number="920.110" title="Ordinaziun chantunala davart il guaud">
+            <file category="main" description="920.110.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3118?locale=rm"
+                title="920.110.pdf" />
+
+        </document>
+        <document abbreviation="Raumplanungsgesetz, RPG" authority="chanzlia federala"
+            authority_url="https://www.bk.admin.ch/" category="related" doctype="edict"
+            enactment_date="2019-01-01" federal_level="Confederaziun" id="5" index="10"
+            language="de" number="SR 700" title="Bundesgesetz über die Raumplanung">
+            <file category="main" description="700.de.pdf"
+                href="https://www.lexfind.ch/tolv/247302/de" title="700.de.pdf" />
+
+        </document>
+        <document abbreviation="LSV" authority="chanzlia federala"
+            authority_url="https://www.bk.admin.ch/" category="related" doctype="edict"
+            enactment_date="2024-11-01" federal_level="Confederaziun" id="11" index="620"
+            language="de" number="SR 814.41" title="Lärmschutz-Verordnung">
+            <file category="main" description="814.41.de.pdf"
+                href="https://www.lexfind.ch/tolv/247358/de" title="814.41.de.pdf" />
+
+        </document>
+        <document abbreviation="Waldgesetz, WaG" authority="chanzlia federala"
+            authority_url="https://www.bk.admin.ch/" category="related" doctype="edict"
+            enactment_date="2022-01-01" federal_level="Confederaziun" id="13" index="710"
+            language="de" number="SR 921.0" title="Bundesgesetz über den Wald">
+            <file category="main" description="921.0.de.pdf"
+                href="https://www.lexfind.ch/tolv/246994/de" title="921.0.de.pdf" />
+
+        </document>
+        <document abbreviation="Waldverordnung, WaV" authority="chanzlia federala"
+            authority_url="https://www.bk.admin.ch/" category="related" doctype="edict"
+            enactment_date="2021-07-01" federal_level="Confederaziun" id="14" index="720"
+            language="de" number="SR 921.01" title="Verordnung über den Wald">
+            <file category="main" description="921.01.de.pdf"
+                href="https://www.lexfind.ch/tolv/207456/de" title="921.01.de.pdf" />
+
+        </document>
+    </geolinks>
+
+    <geolinks language="it">
+        <document authority="Amministrazione comunale" authority_url="https://www.domleschg.ch"
+            category="main" doctype="decree" enactment_date="2012-06-22" federal_level="Comune"
+            id="400" language="de" municipality="Domleschg" number="12.GDEf1"
+            subtype="Domleschg (Paspels) 3634" title="Quartierplan Radiend"
+            type="Pianificazione dell'utilizzazione - Procedura del piano di quartiere">
+            <file category="main" description="3634_B_QP_Radiend_Platzhalter.pdf"
+                href="/api/attachments/1123" title="3634_B_QP_Radiend_Platzhalter.pdf" />
+            <file category="additional" description="" href="/api/attachments/6027"
+                title="PlatzhalterFehlendeDokumente.pdf" />
+
+        </document>
+        <document authority="Amministrazione comunale" authority_url="https://www.domleschg.ch"
+            category="related" doctype="decree" enactment_date="2006-09-19" federal_level="Comune"
+            id="390" language="de" municipality="Domleschg" number="3634.(1)"
+            title="Baugesetz Paspels">
+            <file category="main" description="3634_V_Paspels_BauG.pdf"
+                href="/api/attachments/17740" title="3634_V_Paspels_BauG.pdf" />
+
+        </document>
+        <document abbreviation="LPTC" authority="Cancelleria dello Stato"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="2004-12-06"
+            doctype="edict" enactment_date="2019-04-01" federal_level="Cantone" id="17" index="1000"
+            language="it" number="801.100"
+            title="Legge sulla pianificazione territoriale del Cantone dei Grigioni">
+            <file category="main" description="801.100.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3045?locale=it"
+                title="801.100.pdf" />
+
+        </document>
+        <document abbreviation="OPTC" authority="Cancelleria dello Stato"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="2005-05-24"
+            doctype="edict" enactment_date="2023-09-01" federal_level="Cantone" id="18" index="1000"
+            language="it" number="801.110"
+            title="Ordinanza sulla pianificazione territoriale del Cantone dei Grigioni">
+            <file category="main" description="801.110.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3335?locale=it"
+                title="801.110.pdf" />
+
+        </document>
+        <document abbreviation="" authority="Cancelleria dello Stato"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="1997-05-06"
+            doctype="edict" enactment_date="2007-01-01" federal_level="Cantone" id="34" index="1000"
+            language="it" number="801.500"
+            title="Direttive per la pianificazione delle zone di pericolo">
+            <file category="main" description="801.500.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2417?locale=it"
+                title="801.500.pdf" />
+
+        </document>
+        <document abbreviation="Legge cantonale sulla protezione dell'ambiente, LCPAmb"
+            authority="Cancelleria dello Stato" authority_url="http://www.staka.gr.ch"
+            category="related" decree_date="2001-12-02" doctype="edict" enactment_date="2020-04-01"
+            federal_level="Cantone" id="19" index="1000" language="it" number="820.100"
+            title="Legge d'introduzione alla legge federale sulla protezione dell'ambiente">
+            <file category="main" description="820.100.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3025?locale=it"
+                title="820.100.pdf" />
+
+        </document>
+        <document abbreviation="LCFo" authority="Cancelleria dello Stato"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="2012-06-11"
+            doctype="edict" enactment_date="2021-01-01" federal_level="Cantone" id="23" index="1000"
+            language="it" number="920.100" title="Legge cantonale sulle foreste">
+            <file category="main" description="920.100.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3117?locale=it"
+                title="920.100.pdf" />
+
+        </document>
+        <document abbreviation="OCFo" authority="Cancelleria dello Stato"
+            authority_url="http://www.staka.gr.ch" category="related" decree_date="2012-12-03"
+            doctype="edict" enactment_date="2021-01-01" federal_level="Cantone" id="24" index="1000"
+            language="it" number="920.110" title="Ordinanza cantonale sulle foreste">
+            <file category="main" description="920.110.pdf"
+                href="https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/3118?locale=it"
+                title="920.110.pdf" />
+
+        </document>
+        <document abbreviation="Legge sulla pianificazione del territorio, LPT"
+            authority="Cancelleria federale" authority_url="https://www.bk.admin.ch/"
+            category="related" doctype="edict" enactment_date="2019-01-01"
+            federal_level="Confederazione" id="5" index="10" language="it" number="RS 700"
+            title="Legge federale sulla pianificazione del territorio">
+            <file category="main" description="700.it.pdf"
+                href="https://www.lexfind.ch/tolv/247302/it" title="700.it.pdf" />
+
+        </document>
+        <document abbreviation="OIF" authority="Cancelleria federale"
+            authority_url="https://www.bk.admin.ch/" category="related" doctype="edict"
+            enactment_date="2024-11-01" federal_level="Confederazione" id="11" index="620"
+            language="it" number="RS 814.41" title="Ordinanza contro l’inquinamento fonico">
+            <file category="main" description="814.41.it.pdf"
+                href="https://www.lexfind.ch/tolv/247358/it" title="814.41.it.pdf" />
+
+        </document>
+        <document abbreviation="Legge forestale, LFo" authority="Cancelleria federale"
+            authority_url="https://www.bk.admin.ch/" category="related" doctype="edict"
+            enactment_date="2022-01-01" federal_level="Confederazione" id="13" index="710"
+            language="it" number="RS 921.0" title="Legge federale sulle foreste">
+            <file category="main" description="921.0.it.pdf"
+                href="https://www.lexfind.ch/tolv/246994/it" title="921.0.it.pdf" />
+
+        </document>
+        <document abbreviation="OFo" authority="Cancelleria federale"
+            authority_url="https://www.bk.admin.ch/" category="related" doctype="edict"
+            enactment_date="2021-07-01" federal_level="Confederazione" id="14" index="720"
+            language="it" number="RS 921.01" title="Ordinanza sulle foreste">
+            <file category="main" description="921.01.it.pdf"
+                href="https://www.lexfind.ch/tolv/207456/it" title="921.01.it.pdf" />
+
+        </document>
+    </geolinks>
+
+</multilang_geolinks>

--- a/tests/resources/prepublink_v1.2.5.xml
+++ b/tests/resources/prepublink_v1.2.5.xml
@@ -1,0 +1,43 @@
+<prepublinks language="de">
+    <document authority="Gemeindeverwaltung" authority_url="https://www.binningen.ch"
+        category="main" doctype="prepublication" federal_level="Gemeinde" id="8087"
+        instance="Gemeinde" language="de" municipality="Binningen"
+        status="RBG (1) beschlossen, Genehmigungsantrag ausstehend" status_start_date="2024-08-26"
+        subtype="Zonenplan" title="11/ZPS/2/x_Zone mit Quartierplanpflicht Spiesshöfli"
+        type="Nutzungsplan">
+        <file category="main" description="20240826_ERB_Binningen.pdf" href="/api/attachments/19090"
+            title="20240826_ERB_Binningen.pdf" />
+    </document>
+    <document authority="Gemeindeverwaltung" authority_url="https://www.binningen.ch"
+        category="related" decree_date="2013-09-17" doctype="decree" enactment_date="2013-09-17"
+        federal_level="Gemeinde" id="1254" language="de" municipality="Binningen"
+        number="11/ZRS/2/0" title="Zonenreglement Siedlung">
+        <file category="main" description="11_ZRS_02_00_N_G_2013_1521_oereb.pdf"
+            href="/api/attachments/18516" title="11_ZRS_02_00_N_G_2013_1521_oereb.pdf" />
+    </document>
+    <document abbreviation="RBG" authority="Landeskanzlei;BUD GSK"
+        authority_url="https://www.baselland.ch/politik-und-behorden/besondere-behoerden/bv-bb/landeskanzlei;https://www.baselland.ch/politik-und-behorden/direktionen/bau-und-umweltschutzdirektion/generalsekretariat"
+        category="related" decree_date="1998-01-08" doctype="edict" enactment_date="2024-01-01"
+        federal_level="Kanton" id="3" index="731" language="de" number="400"
+        title="Raumplanungs- und Baugesetz">
+        <file category="main" description="400.pdf"
+            href="https://bl.clex.ch/frontend/versions/pdf_file_with_annex/3813?locale=de"
+            title="400.pdf" />
+    </document>
+    <document abbreviation="RBV" authority="Landeskanzlei"
+        authority_url="https://www.baselland.ch/politik-und-behorden/besondere-behoerden/bv-bb/landeskanzlei"
+        category="related" decree_date="1998-10-27" doctype="edict" enactment_date="2024-01-01"
+        federal_level="Kanton" id="16" index="741" language="de" number="400.11"
+        title="Verordnung zum Raumplanungs- und Baugesetz">
+        <file category="main" description="400.11.pdf"
+            href="https://bl.clex.ch/frontend/versions/pdf_file_with_annex/3836?locale=de"
+            title="400.11.pdf" />
+    </document>
+    <document abbreviation="Raumplanungsgesetz, RPG" authority="Bundeskanzlei"
+        authority_url="https://www.bk.admin.ch/bk/de/home.html" category="related" doctype="edict"
+        enactment_date="2019-01-01" federal_level="Bund" id="1" index="10" language="de"
+        number="700" title="Bundesgesetz über die Raumplanung">
+        <file category="main" description="700.de.pdf" href="https://www.lexfind.ch/tolv/247302/de"
+            title="700.de.pdf" />
+    </document>
+</prepublinks>

--- a/tests/resources/prepublink_v1.2.5_ml.xml
+++ b/tests/resources/prepublink_v1.2.5_ml.xml
@@ -1,0 +1,45 @@
+<multilang_prepublinks>
+    <prepublinks language="de">
+        <document authority="Gemeindeverwaltung" authority_url="https://www.binningen.ch"
+            category="main" doctype="prepublication" federal_level="Gemeinde" id="8087"
+            instance="Gemeinde" language="de" municipality="Binningen"
+            status="RBG (1) beschlossen, Genehmigungsantrag ausstehend"
+            status_start_date="2024-08-26" subtype="Zonenplan"
+            title="11/ZPS/2/x_Zone mit Quartierplanpflicht Spiesshöfli" type="Nutzungsplan">
+            <file category="main" description="20240826_ERB_Binningen.pdf"
+                href="/api/attachments/19090" title="20240826_ERB_Binningen.pdf" />
+        </document>
+        <document authority="Gemeindeverwaltung" authority_url="https://www.binningen.ch"
+            category="related" decree_date="2013-09-17" doctype="decree" enactment_date="2013-09-17"
+            federal_level="Gemeinde" id="1254" language="de" municipality="Binningen"
+            number="11/ZRS/2/0" title="Zonenreglement Siedlung">
+            <file category="main" description="11_ZRS_02_00_N_G_2013_1521_oereb.pdf"
+                href="/api/attachments/18516" title="11_ZRS_02_00_N_G_2013_1521_oereb.pdf" />
+        </document>
+        <document abbreviation="RBG" authority="Landeskanzlei;BUD GSK"
+            authority_url="https://www.baselland.ch/politik-und-behorden/besondere-behoerden/bv-bb/landeskanzlei;https://www.baselland.ch/politik-und-behorden/direktionen/bau-und-umweltschutzdirektion/generalsekretariat"
+            category="related" decree_date="1998-01-08" doctype="edict" enactment_date="2024-01-01"
+            federal_level="Kanton" id="3" index="731" language="de" number="400"
+            title="Raumplanungs- und Baugesetz">
+            <file category="main" description="400.pdf"
+                href="https://bl.clex.ch/frontend/versions/pdf_file_with_annex/3813?locale=de"
+                title="400.pdf" />
+        </document>
+        <document abbreviation="RBV" authority="Landeskanzlei"
+            authority_url="https://www.baselland.ch/politik-und-behorden/besondere-behoerden/bv-bb/landeskanzlei"
+            category="related" decree_date="1998-10-27" doctype="edict" enactment_date="2024-01-01"
+            federal_level="Kanton" id="16" index="741" language="de" number="400.11"
+            title="Verordnung zum Raumplanungs- und Baugesetz">
+            <file category="main" description="400.11.pdf"
+                href="https://bl.clex.ch/frontend/versions/pdf_file_with_annex/3836?locale=de"
+                title="400.11.pdf" />
+        </document>
+        <document abbreviation="Raumplanungsgesetz, RPG" authority="Bundeskanzlei"
+            authority_url="https://www.bk.admin.ch/bk/de/home.html" category="related"
+            doctype="edict" enactment_date="2019-01-01" federal_level="Bund" id="1" index="10"
+            language="de" number="700" title="Bundesgesetz über die Raumplanung">
+            <file category="main" description="700.de.pdf"
+                href="https://www.lexfind.ch/tolv/247302/de" title="700.de.pdf" />
+        </document>
+    </prepublinks>
+</multilang_prepublinks>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -428,59 +428,6 @@ def test_dtd_validation_invalid():
         )
 
 
-@pytest.mark.parametrize('docs,exp_docs_filtered', [
-    (
-        [
-            Document([], id=1, language_link='de'),
-            Document([], id=1, language_link='fr'),
-            Document([], id=2, language_link='de')],
-        [
-            Document([], id=1, language_link='de'),
-            Document([], id=1, language_link='fr'),
-            Document([], id=2, language_link='de')]
-    ),
-    (
-        [
-            Document([], id=2, language_link='de'),
-            Document([], id=1, language_link='fr'),
-            Document([], id=1, language_link='de'),
-            Document([], id=2, language_link='fr'),
-            Document([], id=2, language_link='de')
-        ],
-        [
-            Document([], id=1, language_link='de'),
-            Document([], id=1, language_link='fr'),
-            Document([], id=2, language_link='de'),
-            Document([], id=2, language_link='fr')
-        ]
-    ),
-    (
-        [
-            Document([], id=2, language_link='de'),
-            Document([], id=1, language_link=None),
-            Document([], id=2, language_link=None),
-            Document([], id=1, language_link=None)
-        ],
-        [
-            Document([], id=2, language_link='de'),
-            Document([], id=1, language_link=None),
-            Document([], id=2, language_link=None),
-        ]
-    )
-])
-def test_filter_duplicated_documents(docs, exp_docs_filtered):
-
-    result = XML()._filter_duplicated_documents(docs)
-
-    result = sorted(result, key=lambda x: (x.id, (x.language_link is None, x.language_link)), reverse=False)
-
-    exp_docs_filtered = sorted(
-        exp_docs_filtered, key=lambda x: (x.id, (x.language_link is None, x.language_link)), reverse=False)
-
-    assert [[x.id, x.language_link] for x in result] == \
-        [[x.id, x.language_link] for x in exp_docs_filtered]
-
-
 @pytest.fixture()
 def provide_geolinks_el():
     geolinks_el = Element('geolinks', attrib={'language': 'de'})

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -375,11 +375,13 @@ def test_schema_version_1_2_5():
     assert documents[-3].id == '11'
     assert documents[-2].id == '13'
     assert documents[-1].id == '14'
+    assert documents[0].language_document == 'de'
+    assert documents[0].language_link == 'de'
 
 
 def test_schema_version_1_2_5_ml():
     """
-    test of schema version 1.2.5
+    test of schema version 1.2.5 multilang
     """
     with requests_mock.mock() as mock_m:
         with open('tests/resources/geolink_v1.2.5_ml.xml', 'rb') as file_f:
@@ -398,6 +400,54 @@ def test_schema_version_1_2_5_ml():
     assert documents[-3].id == '11'
     assert documents[-2].id == '13'
     assert documents[-1].id == '14'
+    assert documents[0].language_document == 'de'
+    assert documents[0].language_link == 'de'
+    assert documents[2].language_document == 'de'
+    assert documents[2].language_link == 'de'
+    assert documents[12].language_document == 'de'
+    assert documents[12].language_link == 'rm'
+    assert documents[14].language_document == 'rm'
+    assert documents[14].language_link == 'rm'
+    assert documents[24].language_document == 'de'
+    assert documents[24].language_link == 'it'
+    assert documents[26].language_document == 'it'
+    assert documents[26].language_link == 'it'
+
+
+def test_schema_version_1_2_5_prepublink():
+    """
+    test of schema version 1.2.5: prepublink
+    """
+    with requests_mock.mock() as mock_m:
+        with open('tests/resources/prepublink_v1.2.5.xml', 'rb') as file_f:
+            mock_m.get('http://oereblex.test.com/api/prepubs/1500.xml', content=file_f.read())
+        documents = XML(version=SCHEMA.V1_2_5).from_url('http://oereblex.test.com/api/prepubs/1500.xml')
+    assert len(documents) == 5
+    assert documents[0].index is None
+    assert documents[1].index is None
+    assert documents[-3].index == 731
+    assert documents[-2].index == 741
+    assert documents[-1].index == 10
+    assert documents[0].language_document == 'de'
+    assert documents[0].language_link == 'de'
+
+
+def test_schema_version_1_2_5_prepublink_ml():
+    """
+    test of schema version 1.2.5: prepublink multilang
+    """
+    with requests_mock.mock() as mock_m:
+        with open('tests/resources/prepublink_v1.2.5_ml.xml', 'rb') as file_f:
+            mock_m.get('http://oereblex.test.com/api/prepubs/1500.xml', content=file_f.read())
+        documents = XML(version=SCHEMA.V1_2_5).from_url('http://oereblex.test.com/api/prepubs/1500.xml')
+    assert len(documents) == 5
+    assert documents[0].index is None
+    assert documents[1].index is None
+    assert documents[-3].index == 731
+    assert documents[-2].index == 741
+    assert documents[-1].index == 10
+    assert documents[0].language_document == 'de'
+    assert documents[0].language_link == 'de'
 
 
 def test_default_version_with_locale():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 import pytest
 import requests_mock
-from lxml.etree import DocumentInvalid, _Element
 import xmlschema
+from unittest.mock import patch
+from lxml.etree import DocumentInvalid, _Element, Element, SubElement
 from requests import RequestException
 
 from geolink_formatter.parser import XML, SCHEMA
+from geolink_formatter.entity import Document
 
 
 def test_xml_init():
@@ -351,6 +353,53 @@ def test_schema_version_1_2_4_faulty_geolink():
             XML(version=SCHEMA.V1_2_4).from_url('http://oereblex.test.com/api/geolinks/1500.xml')
 
 
+def test_schema_version_1_2_5():
+    """
+    test of schema version 1.2.5
+    """
+    with requests_mock.mock() as mock_m:
+        with open('tests/resources/geolink_v1.2.5.xml', 'rb') as file_f:
+            mock_m.get('http://oereblex.test.com/api/geolinks/1500.xml', content=file_f.read())
+        documents = XML(version=SCHEMA.V1_2_5).from_url('http://oereblex.test.com/api/geolinks/1500.xml')
+    assert len(documents) == 12
+    assert documents[0].index is None
+    assert documents[0].id == '400'
+    assert documents[-11].id == '390'
+    assert documents[-10].id == '17'
+    assert documents[-9].id == '18'
+    assert documents[-8].id == '34'
+    assert documents[-7].id == '19'
+    assert documents[-6].id == '23'
+    assert documents[-5].id == '24'
+    assert documents[-4].id == '5'
+    assert documents[-3].id == '11'
+    assert documents[-2].id == '13'
+    assert documents[-1].id == '14'
+
+
+def test_schema_version_1_2_5_ml():
+    """
+    test of schema version 1.2.5
+    """
+    with requests_mock.mock() as mock_m:
+        with open('tests/resources/geolink_v1.2.5_ml.xml', 'rb') as file_f:
+            mock_m.get('http://oereblex.test.com/api/geolinks/1500.xml', content=file_f.read())
+        documents = XML(version=SCHEMA.V1_2_5).from_url('http://oereblex.test.com/api/geolinks/1500.xml')
+    assert len(documents) == 36
+    assert documents[0].id == '400'
+    assert documents[-11].id == '390'
+    assert documents[-10].id == '17'
+    assert documents[-9].id == '18'
+    assert documents[-8].id == '34'
+    assert documents[-7].id == '19'
+    assert documents[-6].id == '23'
+    assert documents[-5].id == '24'
+    assert documents[-4].id == '5'
+    assert documents[-3].id == '11'
+    assert documents[-2].id == '13'
+    assert documents[-1].id == '14'
+
+
 def test_default_version_with_locale():
     with requests_mock.mock() as mock_m:
         with open('tests/resources/geolink_v1.2.1.xml', 'rb') as file_f:
@@ -377,3 +426,119 @@ def test_dtd_validation_invalid():
             <root></root>
             """
         )
+
+
+@pytest.mark.parametrize('docs,exp_docs_filtered', [
+    (
+        [
+            Document([], id=1, language_link='de'),
+            Document([], id=1, language_link='fr'),
+            Document([], id=2, language_link='de')],
+        [
+            Document([], id=1, language_link='de'),
+            Document([], id=1, language_link='fr'),
+            Document([], id=2, language_link='de')]
+    ),
+    (
+        [
+            Document([], id=2, language_link='de'),
+            Document([], id=1, language_link='fr'),
+            Document([], id=1, language_link='de'),
+            Document([], id=2, language_link='fr'),
+            Document([], id=2, language_link='de')
+        ],
+        [
+            Document([], id=1, language_link='de'),
+            Document([], id=1, language_link='fr'),
+            Document([], id=2, language_link='de'),
+            Document([], id=2, language_link='fr')
+        ]
+    ),
+    (
+        [
+            Document([], id=2, language_link='de'),
+            Document([], id=1, language_link=None),
+            Document([], id=2, language_link=None),
+            Document([], id=1, language_link=None)
+        ],
+        [
+            Document([], id=2, language_link='de'),
+            Document([], id=1, language_link=None),
+            Document([], id=2, language_link=None),
+        ]
+    )
+])
+def test_filter_duplicated_documents(docs, exp_docs_filtered):
+
+    result = XML()._filter_duplicated_documents(docs)
+
+    result = sorted(result, key=lambda x: (x.id, (x.language_link is None, x.language_link)), reverse=False)
+
+    exp_docs_filtered = sorted(
+        exp_docs_filtered, key=lambda x: (x.id, (x.language_link is None, x.language_link)), reverse=False)
+
+    assert [[x.id, x.language_link] for x in result] == \
+        [[x.id, x.language_link] for x in exp_docs_filtered]
+
+
+@pytest.fixture()
+def provide_geolinks_el():
+    geolinks_el = Element('geolinks', attrib={'language': 'de'})
+    SubElement(geolinks_el, 'document', attrib={'id': '1'})
+    SubElement(geolinks_el, 'document', attrib={'id': '2'})
+    yield geolinks_el
+
+
+def test_process_geolinks_prepublinks(provide_geolinks_el):
+    with patch.object(
+        XML,
+        '_process_single_document',
+        return_value=Document([], id=1, language_link='de')
+    ):
+        result = XML()._process_geolinks_prepublinks(provide_geolinks_el)
+        assert all([isinstance(x, Document) for x in result])
+        assert len(result) == 2
+
+
+@pytest.fixture()
+def provide_document_el():
+    document_el = Element(
+        'document',
+        attrib={
+            'language': 'de',
+            'authority': 'Gemeindeverwaltung',
+            'authority_url': 'https://www.domleschg.ch',
+            'category': 'main',
+            'doctype': 'decree',
+            'enactment_date': '2012-06-22',
+            'federal_level': 'Gemeinde',
+            'id': '400',
+            'language': 'de',
+            'municipality': 'Domleschg',
+            'number': '12.GDEf1',
+            'subtype': 'Domleschg (Paspels) 3634',
+            'title': 'Quartierplan Radiend',
+            'type': 'Nutzungsplanung - Quartierplanverfahren'
+        }
+    )
+    SubElement(document_el, 'file', attrib={
+        'category': 'main',
+        'description': '3634_B_QP_Radiend_Platzhalter.pdf',
+        'href': '/api/attachments/1123',
+        'title': '3634_B_QP_Radiend_Platzhalter.pdf'
+    })
+    SubElement(document_el, 'file', attrib={
+        'category': 'additional',
+        'description': '',
+        'href': '/api/attachments/6027',
+        'title': 'PlatzhalterFehlendeDokumente.pdf'
+    })
+
+    yield document_el
+
+
+def test_process_single_document(provide_document_el):
+    document = XML()._process_single_document(provide_document_el, language_link='de')
+    assert document.id == '400'
+    assert document.language_link == 'de'
+    assert document.files[1].title == 'PlatzhalterFehlendeDokumente.pdf'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+import pytest
+from geolink_formatter.utils import filter_duplicated_documents
+from geolink_formatter.entity import Document
+
+
+@pytest.mark.parametrize('docs,exp_docs_filtered', [
+    (
+        [
+            Document([], id=1, language_link='de'),
+            Document([], id=1, language_link='fr'),
+            Document([], id=2, language_link='de')],
+        [
+            Document([], id=1, language_link='de'),
+            Document([], id=1, language_link='fr'),
+            Document([], id=2, language_link='de')]
+    ),
+    (
+        [
+            Document([], id=2, language_link='de'),
+            Document([], id=1, language_link='fr'),
+            Document([], id=1, language_link='de'),
+            Document([], id=2, language_link='fr'),
+            Document([], id=2, language_link='de')
+        ],
+        [
+            Document([], id=1, language_link='de'),
+            Document([], id=1, language_link='fr'),
+            Document([], id=2, language_link='de'),
+            Document([], id=2, language_link='fr')
+        ]
+    ),
+    (
+        [
+            Document([], id=2, language_link='de'),
+            Document([], id=1, language_link=None),
+            Document([], id=2, language_link=None),
+            Document([], id=1, language_link=None)
+        ],
+        [
+            Document([], id=2, language_link='de'),
+            Document([], id=1, language_link=None),
+            Document([], id=2, language_link=None),
+        ]
+    )
+])
+def test_filter_duplicated_documents(docs, exp_docs_filtered):
+
+    result = filter_duplicated_documents(docs)
+
+    result = sorted(result, key=lambda x: (x.id, (x.language_link is None, x.language_link)), reverse=False)
+
+    exp_docs_filtered = sorted(
+        exp_docs_filtered, key=lambda x: (x.id, (x.language_link is None, x.language_link)), reverse=False)
+
+    assert [[x.id, x.language_link] for x in result] == \
+        [[x.id, x.language_link] for x in exp_docs_filtered]


### PR DESCRIPTION
Add support of oereblex api version 1.2.5

Changes:
- geolink_formatter.entity.Document:
  -  new attributes "language_document", "laguage_link"
- geolink_formatter.parser:
  - changing / adding methods in order to enable the parsing of xml-docs of api version 1.2.5  