### PR TITLE
add support for oereblex api version 1.2.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Change log
 unreleased
 ----------
 
+
 2.0.7
 -----
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,13 @@ Change log
 unreleased
 ----------
 
+2.0.7
+-----
+
+Supported GEO-Link API versions: v1.0.0, v1.1.0, v1.1.1, v1.2.0, v1.2.1, v1.2.2, v1.2.3, v1.2.4, v1.2.5, v1.2.6 (default)
+
+- Dependency updates
+
 2.0.6
 -----
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,6 @@ Change log
 unreleased
 ----------
 
-
 2.0.7
 -----
 

--- a/geolink_formatter/parser.py
+++ b/geolink_formatter/parser.py
@@ -39,13 +39,16 @@ class SCHEMA(object):
     V1_2_5 = '1.2.5'
     """str: geoLink schema version 1.2.5"""
 
+    V1_2_6 = '1.2.6'
+    """str: geoLink schema version 1.2.6"""
+
 
 class XML(object):
 
     _date_format = '%Y-%m-%d'
     """str: Format of date values in XML."""
 
-    def __init__(self, host_url=None, version='1.2.5', dtd_validation=False, xsd_validation=True):
+    def __init__(self, host_url=None, version='1.2.6', dtd_validation=False, xsd_validation=True):
         """Create a new XML parser instance containing the geoLink XSD for validation.
 
         Args:

--- a/geolink_formatter/schema/v1.2.6.xsd
+++ b/geolink_formatter/schema/v1.2.6.xsd
@@ -1,0 +1,113 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:element name="multilang_geolinks">
+    <xs:complexType>
+      <xs:choice minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="geolinks" type="base_links" />
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="geolinks" type="base_links" />
+
+  <xs:element name="multilang_prepublinks">
+    <xs:complexType>
+      <xs:choice minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="prepublinks" type="base_links" />
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="prepublinks" type="base_links" />
+
+  <xs:complexType name="base_links">
+    <xs:sequence>
+      <xs:element name="document" type="full_document" minOccurs="1" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute name="language" type="language" />
+  </xs:complexType>
+
+  <xs:complexType name="full_document">
+    <xs:complexContent>
+      <xs:extension base="base_document">
+        <xs:attributeGroup ref="geolink_document" />
+        <xs:attributeGroup ref="prepublink_document" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:attributeGroup name="geolink_document">
+    <xs:attribute name="abrogation_date" type="xs:date" />
+    <xs:attribute name="approval_date" type="xs:date" />
+    <xs:attribute name="decree_date" type="xs:date" />
+    <xs:attribute name="enactment_date" type="xs:date" />
+    <xs:attribute name="publication_date" type="xs:date" />
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="prepublink_document">
+    <xs:attribute name="status" type="xs:string" />
+    <xs:attribute name="status_end_date" type="xs:date" />
+    <xs:attribute name="status_start_date" type="xs:date" />
+  </xs:attributeGroup>
+
+  <xs:complexType name="base_document">
+    <xs:sequence>
+      <xs:element name="file" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:attribute name="category">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="main" />
+                <xs:enumeration value="additional" />
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="href" type="xs:string" />
+          <xs:attribute name="title" type="xs:string" />
+          <xs:attribute name="description" type="xs:string" />
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="abbreviation" type="xs:string" />
+    <xs:attribute name="authority" type="xs:string" />
+    <xs:attribute name="authority_url" type="xs:string" />
+    <xs:attribute name="category">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="main" />
+          <xs:enumeration value="related" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="cycle" type="xs:string" />
+    <xs:attribute name="doctype">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="edict" />
+          <xs:enumeration value="decree" />
+          <xs:enumeration value="notice" />
+          <xs:enumeration value="prepublication" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="federal_level" type="xs:string" />
+    <xs:attribute name="id" type="xs:string" />
+    <xs:attribute name="index" type="xs:integer" />
+    <xs:attribute name="instance" type="xs:string" />
+    <xs:attribute name="language" type="language" />
+    <xs:attribute name="municipality" type="xs:string" />
+    <xs:attribute name="number" type="xs:string" />
+    <xs:attribute name="subtype" type="xs:string" />
+    <xs:attribute name="title" type="xs:string" />
+    <xs:attribute name="type" type="xs:string" />
+  </xs:complexType>
+
+  <xs:simpleType name="language">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="de" />
+      <xs:enumeration value="fr" />
+      <xs:enumeration value="it" />
+      <xs:enumeration value="rm" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
closes https://github.com/openoereb/geolink_formatter/issues/375

added:
- oereblex schema 1.2.6 (copy of schema 1.2.5)
- no tests added as schema v1.2.6 is the same as schema v1.2.5 